### PR TITLE
chat demo

### DIFF
--- a/cpeerconnection.cc
+++ b/cpeerconnection.cc
@@ -309,9 +309,9 @@ CGO_sdpString CGO_SerializeSDP(CGO_sdp sdp) {
 }
 
 // Given a fully serialized SDP string |msg|, return a CGO sdp object.
-CGO_sdp CGO_DeserializeSDP(char *msg) {
+CGO_sdp CGO_DeserializeSDP(char *type, char *msg) {
   // TODO: Look into type.
-  auto jsep_sdp = new JsepSessionDescription("offer");
+  auto jsep_sdp = new JsepSessionDescription(type);
   SdpParseError err;
   auto msg_str = new string(msg);
   SdpDeserialize(*msg_str, jsep_sdp, &err);

--- a/cpeerconnection.h
+++ b/cpeerconnection.h
@@ -51,7 +51,7 @@ extern "C" {
   CGO_sdp CGO_CreateAnswer(CGO_Peer);
 
   CGO_sdpString CGO_SerializeSDP(CGO_sdp);
-  CGO_sdp CGO_DeserializeSDP(char *msg);
+  CGO_sdp CGO_DeserializeSDP(char *type, char *msg);
 
   int CGO_SetLocalDescription(CGO_Peer, CGO_sdp);
   int CGO_SetRemoteDescription(CGO_Peer, CGO_sdp);

--- a/data/channel.go
+++ b/data/channel.go
@@ -126,7 +126,7 @@ type Init struct {
 //export cgoChannelOnMessage
 func cgoChannelOnMessage(goChannel unsafe.Pointer, cBytes unsafe.Pointer, size int) {
 	bytes := C.GoBytes(cBytes, C.int(size))
-	fmt.Println("fired data.Channel.OnMessage: ", goChannel, bytes, size)
+	// fmt.Println("fired data.Channel.OnMessage: ", goChannel, bytes, size)
 	dc := (*Channel)(goChannel)
 	if nil != dc.OnMessage {
 		dc.OnMessage(bytes)

--- a/demo/chat/chat.go
+++ b/demo/chat/chat.go
@@ -1,6 +1,7 @@
 /*
  * Webrtc chat demo.
  * Send chat messages via webrtc, over go.
+ * Can interop with the JS client. (Open chat.html in a browser)
  *
  * To use: `go run chat.go`
  */
@@ -9,73 +10,165 @@ package main
 // #cgo LDFLAGS: -L../lib
 import "C"
 import (
-	"github.com/keroserene/go-webrtc"
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"github.com/keroserene/go-webrtc"
+	"github.com/keroserene/go-webrtc/data"
 	"os"
+	"strings"
 )
 
+type Mode int
+
+const (
+	ModeInit Mode = iota
+	ModeConnect
+	ModeChat
+)
+
+var pc *webrtc.PeerConnection
+var dc *data.Channel
+var mode Mode
+var err error
+var username = "Alice"
+
 // Signaling channel can be copy paste.
-func SignalSend(msg string) {
-	fmt.Println("Please provide this string to the other peer:\n")
-	fmt.Println(msg)
+func signalSend(msg string) {
+	fmt.Println("\n ---- Please copy the below to peer ---- \n")
+	fmt.Println(msg + "\n")
 }
 
-func main() {
+func signalRecieve(msg string) {
+	fmt.Println("Received: ", msg)
+	// recv := msg
+	var v interface{}
+	json.Unmarshal([]byte(msg), v)
 
-	webrtc.SetVerbosity(3)
+	// Only do this once it's a valid SDP.
+	if nil == pc {
+		start(false)
+	}
+}
+
+
+type (
+  Description struct {
+		Type string `json:"type"`
+		Sdp string  `json:"sdp"`
+	}
+)
+
+func sendOffer() {
+	offer, err := pc.CreateOffer()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	pc.SetLocalDescription(offer)
+	data := Description{
+			"offer",
+			offer.Description,
+		}
+	bytes, err := json.Marshal(data)
+	message := fmt.Sprintf(`{"desc":%s}`, string(bytes))
+	signalSend(message)
+}
+
+func receiveDescription(desc string) {
+	pc.SetRemoteDescription(desc)
+}
+
+// func	startAnswer := func(offer string) {
+// sdp := webrtc.NewSessionDescription(offer)
+// pc.SetRemoteDescription(sdp)
+// answer, _ := pc.CreateAnswer()
+// signalSend(answer.Description)
+// }
+func prepareDataChannel(channel *data.Channel) {
+	channel.OnOpen = func() {
+		fmt.Println("Data Channel opened!")
+	}
+	channel.OnClose = func() {
+		fmt.Println("Data Channel closed.")
+	}
+	channel.OnMessage = func(msg []byte) {
+		fmt.Println(string(msg))
+	}
+}
+
+func sendChat(msg string) {
+	line := username + ": " + msg
+	fmt.Println(line)
+	dc.Send([]byte(line))
+}
+
+func start(instigator bool) {
+	mode = ModeConnect
+	fmt.Println("Starting up PeerConnection...")
 	config := webrtc.NewConfiguration(
 		webrtc.OptionIceServer("stun:stun.l.google.com:19302"))
-
-	pc, err := webrtc.NewPeerConnection(config)
+	pc, err = webrtc.NewPeerConnection(config)
 	if nil != err {
 		fmt.Println("Failed to create PeerConnection.")
 		return
 	}
 
+	pc.OnNegotiationNeeded = func() {
+		// Initial SDP offer / answer exchange.
+		go sendOffer()
+	}
 	pc.OnSignalingStateChange = func(state webrtc.SignalingState) {
 		fmt.Println("signal changed:", state)
 	}
 	pc.OnIceCandidate = func(candidate webrtc.IceCandidate) {
 		// TODO: use the serializing.
-		SignalSend(candidate.Candidate)
+		signalSend(candidate.Candidate)
 	}
-	pc.OnNegotiationNeeded = func() {
+	pc.OnDataChannel = func(channel *data.Channel) {
+		fmt.Println("Datachannel established...", channel)
+		prepareDataChannel(channel)
 	}
 
+	if instigator {
+		// Attempting to create the first datachannel triggers ICE.
+		fmt.Println("Trying to create a datachannel.")
+		dc, err = pc.CreateDataChannel("init", data.Init{})
+		if nil != err {
+			fmt.Println("Unexpected failure creating data.Channel.")
+			return;
+		}
+		prepareDataChannel(dc)
+	}
+}
+
+func main() {
+	webrtc.SetVerbosity(3)
+
+	mode = ModeInit
 	wait := make(chan int, 1)
-	initiateOffer := func() {
-		offer, _ := pc.CreateOffer()
-		pc.SetLocalDescription(offer)
-		SignalSend(offer.Description)
-	}
-
-	startAnswer := func(offer string) {
-		sdp := webrtc.NewSessionDescription(offer)
-		pc.SetRemoteDescription(sdp)
-		answer, _ := pc.CreateAnswer()
-		SignalSend(answer.Description)
-	}
-
-	fmt.Println("Initiate offer? (y/n)")
-	// scan := bufio.NewScanner(os.Stdin)
-	// for scan.Scan() {
-		// char := scan.Text()
-		// fmt.Println(scan.Text())
-		// if "y" == char {
-			// fmt.Println("woot")
-		// }
-	// }
+	fmt.Println("To initiate PeerConnection, type \"start\".")
+	fmt.Println("Alternatively, input SDP messages from peer.")
 	reader := bufio.NewReader(os.Stdin)
-	text, _ := reader.ReadString('\n')
-	fmt.Println(text)
 
-	go initiateOffer()
-
-	if false {
-		go startAnswer("bad")
+	// Input loop.
+	for true {
+		text, _ := reader.ReadString('\n')
+		switch mode {
+		case ModeInit:
+			if strings.HasPrefix(text, "start") {
+				start(true)
+			} else {
+				signalRecieve(text)
+			}
+		case ModeConnect:
+			signalRecieve(text)
+		case ModeChat:
+			sendChat(text)
+			break;	
+		}
+		text = ""
 	}
-
 	<-wait
 	fmt.Println("done")
 }

--- a/demo/chat/chat.go
+++ b/demo/chat/chat.go
@@ -1,0 +1,81 @@
+/*
+ * Webrtc chat demo.
+ * Send chat messages via webrtc, over go.
+ *
+ * To use: `go run chat.go`
+ */
+package main
+
+// #cgo LDFLAGS: -L../lib
+import "C"
+import (
+	"github.com/keroserene/go-webrtc"
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Signaling channel can be copy paste.
+func SignalSend(msg string) {
+	fmt.Println("Please provide this string to the other peer:\n")
+	fmt.Println(msg)
+}
+
+func main() {
+
+	webrtc.SetVerbosity(3)
+	config := webrtc.NewConfiguration(
+		webrtc.OptionIceServer("stun:stun.l.google.com:19302"))
+
+	pc, err := webrtc.NewPeerConnection(config)
+	if nil != err {
+		fmt.Println("Failed to create PeerConnection.")
+		return
+	}
+
+	pc.OnSignalingStateChange = func(state webrtc.SignalingState) {
+		fmt.Println("signal changed:", state)
+	}
+	pc.OnIceCandidate = func(candidate webrtc.IceCandidate) {
+		// TODO: use the serializing.
+		SignalSend(candidate.Candidate)
+	}
+	pc.OnNegotiationNeeded = func() {
+	}
+
+	wait := make(chan int, 1)
+	initiateOffer := func() {
+		offer, _ := pc.CreateOffer()
+		pc.SetLocalDescription(offer)
+		SignalSend(offer.Description)
+	}
+
+	startAnswer := func(offer string) {
+		sdp := webrtc.NewSessionDescription(offer)
+		pc.SetRemoteDescription(sdp)
+		answer, _ := pc.CreateAnswer()
+		SignalSend(answer.Description)
+	}
+
+	fmt.Println("Initiate offer? (y/n)")
+	// scan := bufio.NewScanner(os.Stdin)
+	// for scan.Scan() {
+		// char := scan.Text()
+		// fmt.Println(scan.Text())
+		// if "y" == char {
+			// fmt.Println("woot")
+		// }
+	// }
+	reader := bufio.NewReader(os.Stdin)
+	text, _ := reader.ReadString('\n')
+	fmt.Println(text)
+
+	go initiateOffer()
+
+	if false {
+		go startAnswer("bad")
+	}
+
+	<-wait
+	fmt.Println("done")
+}

--- a/demo/chat/chat.html
+++ b/demo/chat/chat.html
@@ -3,7 +3,7 @@
   <script src="chat.js"></script>
   <style>
   body {
-    background-color: #000;
+    background-color: #424;
     color: #fff;
     text-align: center;
     font-size: 24px;
@@ -15,13 +15,11 @@
     resize: none;
   }
   .chatarea {
-    position: relative;
-    border: 1px solid #888;
-    padding: 0.5em;
-    width: 50%;
-    min-width: 40em;
-    margin: auto;
+    position: relative; border: none;
+    width: 50%; min-width: 40em;
+    padding: 0.5em; margin: auto;
   }
+  .active { background-color: #252; }
   #chatlog {
     display: block;
     width: 100%;
@@ -43,6 +41,15 @@
     background-color: #ccc;
     border: 1px solid #999;
   }
+  #username {
+    font-size: 120%;
+    padding: 8px 2em; margin: 30px auto;
+    text-align: center;
+    display: block;
+    background-color: #000;
+    color: #999;
+    border: none;
+  }
   #send {
     display: inline-block; position: absolute;
     right: 0; top: 0;  height: 100%;
@@ -51,14 +58,14 @@
     font-size: 150%;
     padding: 0 30px;
   }
-  #copy {
-    width: 100%;
-    color: #888;
-  }
+  #send:hover { background-color: #636; }
   </style>
 </head>
 <body>
   <h1>go-webrtc chat demo</h1>
+
+  username:
+  <input type="text" id="username" value="">
 
   <div class="chatarea">
     <textarea id="chatlog" readonly>
@@ -69,9 +76,5 @@
     </div>
   </div>
 
-  <h2>"Signal Channel"</h2>
-  <textarea id="copy" readonly>
-    Copy text from here to peer.
-  </textarea>
 </body>
 </html> 

--- a/demo/chat/chat.html
+++ b/demo/chat/chat.html
@@ -1,0 +1,77 @@
+<html>
+<head>
+  <script src="chat.js"></script>
+  <style>
+  body {
+    background-color: #000;
+    color: #fff;
+    text-align: center;
+    font-size: 24px;
+    font-family: monospace;
+  }
+  textarea {
+    background-color: #333;
+    color: #fff;
+    resize: none;
+  }
+  .chatarea {
+    position: relative;
+    border: 1px solid #888;
+    padding: 0.5em;
+    width: 50%;
+    min-width: 40em;
+    margin: auto;
+  }
+  #chatlog {
+    display: block;
+    width: 100%;
+    height: 50%;
+    margin-bottom: 1em;
+    padding: 8px;
+  }
+  .inputarea {
+    position: relative;
+    width: 100%;
+    height: 3em;
+    display: block;
+  }
+  #input {
+    display: inline-block;
+    width: 100%; height: 100%;
+    padding: 8px 30px;
+    font-size: 80%;
+    background-color: #ccc;
+    border: 1px solid #999;
+  }
+  #send {
+    display: inline-block; position: absolute;
+    right: 0; top: 0;  height: 100%;
+    background-color: #000; color: #f8f;
+    font-variant: small-caps;
+    font-size: 150%;
+    padding: 0 30px;
+  }
+  #copy {
+    width: 100%;
+    color: #888;
+  }
+  </style>
+</head>
+<body>
+  <h1>go-webrtc chat demo</h1>
+
+  <div class="chatarea">
+    <textarea id="chatlog" readonly>
+    </textarea>
+    <div class="inputarea">
+      <input type="text" id="input">
+      <input type="submit" id="send" value="Send">
+    </div>
+  </div>
+
+  <h2>"Signal Channel"</h2>
+  <textarea id="copy" readonly>
+    Copy text from here to peer.
+  </textarea>
+</body>
+</html> 

--- a/demo/chat/chat.js
+++ b/demo/chat/chat.js
@@ -39,14 +39,15 @@ var Signalling = {
     log("\n");
   },
   receive: function(msg) {
-    if (!pc)
-      start(false);
     var recv;
     try {
       recv = JSON.parse(msg);
     } catch(e) {
       log("Invalid JSON.");
       return;
+    }
+    if (!pc) {
+      start(false);
     }
     var desc = recv['desc']
     var ice = recv['candidate']
@@ -137,7 +138,7 @@ function sendAnswer() {
 function receiveDescription(desc) {
   var sdp = new RTCSessionDescription(desc);
   try {
-    pc.setRemoteDescription(sdp);
+    err = pc.setRemoteDescription(sdp);
   } catch (e) {
     log("Invalid SDP message.");
     return false;

--- a/demo/chat/chat.js
+++ b/demo/chat/chat.js
@@ -180,8 +180,17 @@ function prepareDataChannel(channel) {
     log("Data channel error!!");
   }
   channel.onmessage = function(msg) {
-    log(msg.data);
+    var recv = msg.data;
     console.log(msg);
+    // Go sends only raw bytes.
+    if ("[object ArrayBuffer]" == recv.toString()) {
+      var bytes = new Uint8Array(recv);
+      line = String.fromCharCode.apply(null, bytes);
+    } else {
+      line = recv;
+    }
+    line = line.trim();
+    log(line);
   }
 }
 

--- a/demo/chat/chat.js
+++ b/demo/chat/chat.js
@@ -1,0 +1,213 @@
+// minimal js webrtc chat client,
+// to try connecting with go-webrtc/demo/chat.go.
+
+// DOM elements
+var $chatlog;
+var $input;
+var $send;
+
+// WebRTC objects
+var config = {
+  iceServers: [
+    { urls: ["stun:stun.l.google.com:19302"] }
+  ]
+}
+var PeerConnection = webkitRTCPeerConnection;
+var pc;  // PeerConnection
+var offer;
+var user = "Alice";
+var channel;
+
+// Janky state machine
+var MODE = {
+  INIT:       0,
+  ACK:        3,
+  CONNECTING: 4,
+  CHAT:       5
+}
+var currentMode = MODE.INIT;
+
+// Signalling channel - just tells user to copy paste to the peer.
+var Signalling = {
+  send: function(msg) {
+    log("\nPlease copy to the peer:\n");
+    log(JSON.stringify(msg));
+    log("\n");
+  },
+  receive: function(msg) {
+    if (!pc)
+      start(false);
+
+    // log("signal received: " + msg);
+    var recv;
+    try {
+      recv = JSON.parse(msg);
+    } catch(e) {
+      log("Invalid JSON.");
+      return;
+    }
+    var desc = recv['desc']
+    var ice = recv['candidate']
+    if (!desc && ! ice) {
+      log("Invalid SDP.");
+      return false;
+    }
+    if (desc) { receiveDescription(desc); }
+    if (ice) { receiveICE(recv); }
+  }
+}
+
+function welcome() {
+  log("== webrtc chat demo ==");
+  log("To initiate PeerConnection, type start. Otherwise, input SDP messages.");
+}
+
+function start(initiator) {
+  log("Starting up RTCPeerConnection...");
+  pc = new PeerConnection(config);
+  pc.onicecandidate = function(evt) {
+    var candidate = evt.candidate;
+    if (!candidate)
+      return;
+    // log("Ice Candidate found.");
+    Signalling.send(candidate);
+  }
+  pc.onnegotiationneeded = function() {
+    // log("Negotiation needed...");
+    sendOffer();
+  }
+  pc.ondatachannel = function(dc) {
+    console.log(dc);
+    channel = dc.channel;
+    log("Data Channel established! ");
+    prepareDataChannel(channel);
+  }
+
+  // Creating the first data channel triggers ICE negotiation.
+  if (initiator) {
+    channel = pc.createDataChannel("test");
+    prepareDataChannel(channel);
+  }
+}
+
+// Local input from keyboard into chat window.
+function acceptInput(is) {
+  var msg = $input.value;
+  switch (currentMode) {
+    case MODE.INIT:
+      if (msg.startsWith("start")) {
+        start(true);
+      } else {
+        Signalling.receive(msg);
+      }
+      break;
+    case MODE.ACK:
+      Signalling.receive(msg);
+      break;
+    case MODE.CHAT:
+      var data = user + ": " + msg;
+      log(data);
+      channel.send(data);
+      break;
+    default:
+      log("ERROR: " + msg);
+  }
+  $input.value = "";
+  $input.focus();
+}
+
+function sendOffer() {
+  pc.createOffer(function(sdp) {
+    offer = sdp;
+    pc.setLocalDescription(sdp);
+    log("webrtc: Created Offer.");
+    Signalling.send({desc: sdp});
+    waitForSignals();
+  });
+}
+
+function sendAnswer() {
+  pc.createAnswer(function (sdp) {
+    pc.setLocalDescription(sdp)
+    log("webrtc: Created Answer.");
+    Signalling.send({desc: sdp});
+  });
+}
+
+function receiveDescription(desc) {
+  var sdp = new RTCSessionDescription(desc);
+  try {
+    pc.setRemoteDescription(sdp);
+  } catch (e) {
+    log("Invalid SDP message.");
+    return false;
+  }
+  // log("SDP set as remote description.\n\n");
+  log("SDP " + sdp.type + " successfully received.");  // + JSON.stringify(desc));
+  if ("offer" == sdp.type) {
+    sendAnswer();
+  }
+  return true;
+}
+
+function receiveICE(ice) {
+  var candidate = new RTCIceCandidate(ice);
+  try {
+    pc.addIceCandidate(candidate);
+  } catch (e) {
+    log("Invalid ICE candidate.");
+  }
+  console.log("ICE candidate received: ", ice);
+}
+
+function waitForSignals() {
+  log("Please input SDP messages from peer.");
+  currentMode = MODE.ACK;
+}
+
+function prepareDataChannel(channel) {
+  channel.onopen = function() {
+    log("Data channel opened!");
+    currentMode = MODE.CHAT;
+  }
+  channel.onclose = function() {
+    log("Data channel closed.");
+    currentMode = MODE.INIT;
+  }
+  channel.onerror = function() {
+    log("Data channel error!!");
+  }
+  channel.onmessage = function(msg) {
+    log(msg.data);
+    console.log(msg);
+  }
+}
+
+function init() {
+  console.log("loaded");
+  // Setup chatwindow.
+  $chatlog = document.getElementById('chatlog');
+  $chatlog.value = "";
+
+  $send = document.getElementById('send');
+  $send.onclick = acceptInput
+
+  $input = document.getElementById('input');
+  $input.focus();
+  $input.onkeydown = function(e) {
+    if (13 == e.keyCode) {  // enter
+      $send.onclick();
+    }
+  }
+  welcome();
+}
+
+var log = function(msg) {
+  $chatlog.value += msg + "\n";
+  console.log(msg);
+  // Scroll to latest.
+  $chatlog.scrollTop = $chatlog.scrollHeight;
+}
+
+document.onload = init;
+window.onload = init;

--- a/webrtc.go
+++ b/webrtc.go
@@ -262,9 +262,9 @@ const (
 var IceTcpCandidateTypeString = []string{"active", "passive", "so"}
 
 type IceCandidate struct {
-	Candidate     string  `json:"candidate"`
-	SdpMid        string  `json:"sdpMid"`
-	SdpMLineIndex int     `json:"sdpMLineIndex"`
+	Candidate     string `json:"candidate"`
+	SdpMid        string `json:"sdpMid"`
+	SdpMLineIndex int    `json:"sdpMLineIndex"`
 	// Foundation     string
 	// Priority       C.ulong
 	// IP             net.IP

--- a/webrtc.go
+++ b/webrtc.go
@@ -104,8 +104,8 @@ type SessionDescription struct {
 }
 
 // Construct a SessionDescription object from a valid msg.
-func NewSessionDescription(msg string) *SessionDescription {
-	cSdp := C.CGO_DeserializeSDP(C.CString(msg))
+func NewSessionDescription(sdpType string, msg string) *SessionDescription {
+	cSdp := C.CGO_DeserializeSDP(C.CString(sdpType), C.CString(msg))
 	if nil == cSdp {
 		ERROR.Println("Invalid SDP string.")
 		return nil
@@ -262,9 +262,9 @@ const (
 var IceTcpCandidateTypeString = []string{"active", "passive", "so"}
 
 type IceCandidate struct {
-	Candidate     string
-	SdpMid        string
-	SdpMLineIndex int
+	Candidate     string  `json:"candidate"`
+	SdpMid        string  `json:"sdpMid"`
+	SdpMLineIndex int     `json:"sdpMLineIndex"`
 	// Foundation     string
 	// Priority       C.ulong
 	// IP             net.IP


### PR DESCRIPTION
Wrote a demo app in `demo/chat/*`, using copy-paste signalling.

Tested by running `go run demo/chat/chat.go`, and also opening `demo/chat/chat.html` in chromium.

Was able to get a PeerConnection + datachannel setup between go-webrtc and browser, including a working chat session. At the moment, this only works if the go-webrtc side initiates the exchange, which indicates there's still some bugginess somewhere along the way to `OnDataChannel`

Still, this is a great milestone, showing that go-webrtc DataChannels work for real! :)