### PR TITLE
Fix an enum translation issue for onConnectionStateChange

### DIFF
--- a/peerconnection.cc
+++ b/peerconnection.cc
@@ -137,8 +137,8 @@ class Peer
       return;
     }
     cgoOnIceConnectionStateChange(goPeerConnection, new_state);
-    // TODO: This may need to be slightly more complicated...
-    // https://w3c.github.io/webrtc-pc/#rtcpeerconnectionstate-enum
+    // The ice connection state is sent to the go callback
+    // which then translates it into RTCPeerConnectionState
     cgoOnConnectionStateChange(goPeerConnection, new_state);
   }
 

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -382,7 +382,25 @@ func cgoOnIceCandidateError(p int) {
 }
 
 //export cgoOnConnectionStateChange
-func cgoOnConnectionStateChange(p int, state PeerConnectionState) {
+func cgoOnConnectionStateChange(p int, iceState IceConnectionState) {
+	// TODO: This may need to be slightly more complicated...
+	// https://w3c.github.io/webrtc-pc/#rtcpeerconnectionstate-enum
+	var state PeerConnectionState
+	switch iceState {
+	case IceConnectionStateNew:
+		state = PeerConnectionStateNew
+	case IceConnectionStateChecking:
+		state = PeerConnectionStateConnecting
+	case IceConnectionStateConnected:
+		state = PeerConnectionStateConnected
+	case IceConnectionStateFailed:
+		state = PeerConnectionStateFailed
+	case IceConnectionStateDisconnected:
+		state = PeerConnectionStateDisconnected
+	default:
+		return
+	}
+
 	INFO.Println("fired OnConnectionStateChange: ", p)
 	pc := PCMap.Get(p).(*PeerConnection)
 	if nil != pc.OnConnectionStateChange {

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -134,17 +134,29 @@ func TestPeerConnection(t *testing.T) {
 
 				Convey("OnConnectionStateChange", func() {
 					success := make(chan PeerConnectionState, 1)
+					expectPeerConnectionState := func(state PeerConnectionState) {
+						select {
+						case r := <-success:
+							So(r, ShouldEqual, state)
+						case <-time.After(time.Second * 1):
+							t.Fatal("Timed out.")
+						}
+					}
 					pc.OnConnectionStateChange = func(state PeerConnectionState) {
 						success <- state
 					}
 					cgoOnConnectionStateChange(pc.index,
-						PeerConnectionStateDisconnected)
-					select {
-					case r := <-success:
-						So(r, ShouldEqual, PeerConnectionStateDisconnected)
-					case <-time.After(time.Second * 1):
-						t.Fatal("Timed out.")
-					}
+						IceConnectionStateNew)
+					expectPeerConnectionState(PeerConnectionStateNew)
+					cgoOnConnectionStateChange(pc.index,
+						IceConnectionStateConnected)
+					expectPeerConnectionState(PeerConnectionStateConnected)
+					cgoOnConnectionStateChange(pc.index,
+						IceConnectionStateFailed)
+					expectPeerConnectionState(PeerConnectionStateFailed)
+					cgoOnConnectionStateChange(pc.index,
+						IceConnectionStateDisconnected)
+					expectPeerConnectionState(PeerConnectionStateDisconnected)
 				})
 
 				Convey("OnDataChannel", func() {


### PR DESCRIPTION
IceConnectionState values were being sent as PeerConnectionState values.

Tested: A variety of local runs and updated the test.