### PR TITLE
Update build.sh for repeatable builds of libwebrtc-magic.a

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,33 +5,55 @@ THIRD_PARTY_DIR="$PROJECT_DIR/third_party"
 WEBRTC_REPO="https://chromium.googlesource.com/external/webrtc"
 WEBRTC_DIR="$THIRD_PARTY_DIR/webrtc"
 WEBRTC_SRC="$WEBRTC_DIR/src"
+DEPOT_TOOLS_DIR="$THIRD_PARTY_DIR/depot_tools"
 OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
-CONFIG="Debug"
+CONFIG="Release"
 COMMIT="f33698296719f956497d2dbff81b5080864a8804"  # branch-heads/52
 
 INCLUDE_DIR="$PROJECT_DIR/include"
 LIB_DIR="$PROJECT_DIR/lib"
 
-# TODO(arlolra): depot_tools
-
-GYP_DEFINES="include_tests=0"
+PATH="$PATH:$DEPOT_TOOLS_DIR"
 
 mkdir -p $THIRD_PARTY_DIR
 mkdir -p $INCLUDE_DIR
 mkdir -p $LIB_DIR
 
+if [[ -d $DEPOT_TOOLS_DIR ]]; then
+	echo "Syncing depot_tools ..."
+	pushd $DEPOT_TOOLS_DIR
+	git pull --rebase || exit 1
+	popd
+else
+	echo "Getting depot_tools ..."
+	mkdir -p $DEPOT_TOOLS_DIR
+	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_DIR || exit 1
+fi
+
 if [[ -d $WEBRTC_DIR ]]; then
-	echo "Sync'ing webrtc ..."
+	echo "Syncing webrtc ..."
+	pushd $WEBRTC_SRC || exit 1
+	if ! git diff-index --quiet HEAD --; then
+		echo -en "\nOpen files present in $WEBRTC_SRC\nReset them? (y/N): "
+		read ANSWER
+		if [ "$ANSWER" != "y" ]; then
+			echo "*** Cancelled ***"
+			exit 1
+		fi
+		git reset --hard HEAD || exit 1
+	fi
+	popd
+
 	pushd $WEBRTC_DIR
-	gclient sync
+	gclient sync --with_branch_heads -r $COMMIT || exit 1
 	popd
 else
 	echo "Getting webrtc ..."
 	mkdir -p $WEBRTC_DIR
 	pushd $WEBRTC_DIR
-	gclient config --name src $WEBRTC_REPO
-	gclient sync
+	gclient config --name src $WEBRTC_REPO || exit 1
+	gclient sync --with_branch_heads -r $COMMIT || exit 1
 	popd
 fi
 
@@ -40,34 +62,51 @@ pushd $WEBRTC_SRC
 git checkout $COMMIT
 popd
 
-echo "Generating build scripts ..."
-pushd $WEBRTC_SRC
-python webrtc/build/gyp_webrtc
+echo "Cleaning webrtc ..."
+pushd $WEBRTC_SRC || exit 1
+rm -rf out/$CONFIG
+popd
+
+echo "Applying webrtc patches ..."
+pushd $WEBRTC_SRC || exit 1
+for PATCH in build_at_webrtc_branch_heads_52.patch; do
+	git apply --check ${PROJECT_DIR}/webrtc_patches/${PATCH} || exit 1
+	git am < ${PROJECT_DIR}/webrtc_patches/${PATCH} || exit 1
+done
 popd
 
 echo "Building webrtc ..."
 pushd $WEBRTC_SRC
-ninja -C out/$CONFIG
+export GYP_DEFINES="include_tests=0 include_examples=0"
+python webrtc/build/gyp_webrtc webrtc/api/api.gyp || exit 1
+ninja -C out/$CONFIG || exit 1
 popd
 
 echo "Copying headers ..."
-pushd $WEBRTC_SRC
+pushd $WEBRTC_SRC || exit 1
+rm -rf "$INCLUDE_DIR"
 for h in $(find webrtc/ -type f -name '*.h')
 do
 	mkdir -p "$INCLUDE_DIR/$(dirname $h)"
 	cp $h "$INCLUDE_DIR/$h"
 done
 popd
+pushd $PROJECT_DIR || exit 1
+git clean -fdx "$INCLUDE_DIR"
+popd
 
 echo "Concatenating libraries ..."
 pushd $WEBRTC_SRC/out/$CONFIG
-# on osx:
-# ls *.a > filelist
-# libtool -static -o libwebrtc-magic.a -filelist filelist
-# strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
-# on linux:
-# ar crs libwebrtc-magic.a $(find . -name '*.o' -not -name '*.main.o')
-mv libwebrtc-magic.a $LIB_DIR/libwebrtc-$OS-$ARCH-magic.a
+if [ "$OS" = "darwin" ]; then
+	ls *.a > filelist
+	libtool -static -o libwebrtc-magic.a -filelist filelist
+	strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
+else
+	ar crs libwebrtc-magic.a $(find . -name '*.o' -not -name '*.main.o' -not -name 'dump_syms_regtest.o')
+fi
+OUT_LIBRARY=$LIB_DIR/libwebrtc-$OS-$ARCH-magic.a
+mv libwebrtc-magic.a ${OUT_LIBRARY}
+echo "Built ${OUT_LIBRARY}"
 popd
 
 echo "Build complete."

--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ if [ "$OS" = "darwin" ]; then
 	libtool -static -o libwebrtc-magic.a -filelist filelist
 	strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
 else
-	ar crs libwebrtc-magic.a $(find . -name '*.o' -not -name '*.main.o' -not -name 'dump_syms_regtest.o')
+	ar crs libwebrtc-magic.a $(find . -name '*.o' -not -name '*.main.o')
 fi
 OUT_LIBRARY=$LIB_DIR/libwebrtc-$OS-$ARCH-magic.a
 mv libwebrtc-magic.a ${OUT_LIBRARY}

--- a/webrtc_patches/build_at_webrtc_branch_heads_52.patch
+++ b/webrtc_patches/build_at_webrtc_branch_heads_52.patch
@@ -1,0 +1,51 @@
+From 79dda9f4fedd0df439f496b244a226167086cb61 Mon Sep 17 00:00:00 2001
+From: Cant Stop The Signal <cantstopthesignals@gmail.com>
+Date: Sun, 4 Dec 2016 16:01:43 -0800
+Subject: [PATCH] Add patches to get webrtc to build from webrtc
+ branch-heads/52
+
+webrtc commit f33698296719f956497d2dbff81b5080864a8804
+---
+ webrtc/api/api.gyp           |  3 +++
+ webrtc/api/fakefieldtrial.cc | 15 +++++++++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 webrtc/api/fakefieldtrial.cc
+
+diff --git a/webrtc/api/api.gyp b/webrtc/api/api.gyp
+index 377ef8f..01b16bc 100644
+--- a/webrtc/api/api.gyp
++++ b/webrtc/api/api.gyp
+@@ -199,6 +199,9 @@
+         'webrtcsession.h',
+         'webrtcsessiondescriptionfactory.cc',
+         'webrtcsessiondescriptionfactory.h',
++        'test/fakeaudiocapturemodule.cc',
++        'test/fakeaudiocapturemodule.h',
++        'fakefieldtrial.cc',
+       ],
+       # TODO(kjellander): Make the code compile without disabling these flags.
+       # See https://bugs.chromium.org/p/webrtc/issues/detail?id=3307
+diff --git a/webrtc/api/fakefieldtrial.cc b/webrtc/api/fakefieldtrial.cc
+new file mode 100644
+index 0000000..24c7ecc
+--- /dev/null
++++ b/webrtc/api/fakefieldtrial.cc
+@@ -0,0 +1,15 @@
++// Copyright 2015 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include <string>
++
++// Define webrtc::field_trial::FindFullName to provide webrtc with a field trial
++// implementation.
++namespace webrtc {
++namespace field_trial {
++std::string FindFullName(const std::string& trial_name) {
++  return std::string();
++}
++}  // namespace field_trial
++}  // namespace webrtc
+-- 
+2.8.0.rc3.226.g39d4020
+

--- a/webrtc_patches/build_at_webrtc_branch_heads_52.patch
+++ b/webrtc_patches/build_at_webrtc_branch_heads_52.patch
@@ -1,4 +1,4 @@
-From 79dda9f4fedd0df439f496b244a226167086cb61 Mon Sep 17 00:00:00 2001
+From dd503bd0c5696882d6ece760da1ef4865825e55c Mon Sep 17 00:00:00 2001
 From: Cant Stop The Signal <cantstopthesignals@gmail.com>
 Date: Sun, 4 Dec 2016 16:01:43 -0800
 Subject: [PATCH] Add patches to get webrtc to build from webrtc
@@ -6,46 +6,30 @@ Subject: [PATCH] Add patches to get webrtc to build from webrtc
 
 webrtc commit f33698296719f956497d2dbff81b5080864a8804
 ---
- webrtc/api/api.gyp           |  3 +++
- webrtc/api/fakefieldtrial.cc | 15 +++++++++++++++
- 2 files changed, 18 insertions(+)
- create mode 100644 webrtc/api/fakefieldtrial.cc
+ webrtc/api/api.gyp | 3 +++
+ 1 file changed, 3 insertions(+)
 
 diff --git a/webrtc/api/api.gyp b/webrtc/api/api.gyp
-index 377ef8f..01b16bc 100644
+index 377ef8f70..794fdb99c 100644
 --- a/webrtc/api/api.gyp
 +++ b/webrtc/api/api.gyp
-@@ -199,6 +199,9 @@
+@@ -129,6 +129,7 @@
+       'dependencies': [
+         '<(webrtc_root)/media/media.gyp:rtc_media',
+         '<(webrtc_root)/pc/pc.gyp:rtc_pc',
++        '<(webrtc_root)/system_wrappers/system_wrappers.gyp:field_trial_default',
+       ],
+       'sources': [
+         'audiotrack.cc',
+@@ -199,6 +200,8 @@
          'webrtcsession.h',
          'webrtcsessiondescriptionfactory.cc',
          'webrtcsessiondescriptionfactory.h',
 +        'test/fakeaudiocapturemodule.cc',
 +        'test/fakeaudiocapturemodule.h',
-+        'fakefieldtrial.cc',
        ],
        # TODO(kjellander): Make the code compile without disabling these flags.
        # See https://bugs.chromium.org/p/webrtc/issues/detail?id=3307
-diff --git a/webrtc/api/fakefieldtrial.cc b/webrtc/api/fakefieldtrial.cc
-new file mode 100644
-index 0000000..24c7ecc
---- /dev/null
-+++ b/webrtc/api/fakefieldtrial.cc
-@@ -0,0 +1,15 @@
-+// Copyright 2015 The Chromium Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style license that can be
-+// found in the LICENSE file.
-+
-+#include <string>
-+
-+// Define webrtc::field_trial::FindFullName to provide webrtc with a field trial
-+// implementation.
-+namespace webrtc {
-+namespace field_trial {
-+std::string FindFullName(const std::string& trial_name) {
-+  return std::string();
-+}
-+}  // namespace field_trial
-+}  // namespace webrtc
 -- 
-2.8.0.rc3.226.g39d4020
+2.11.0
 


### PR DESCRIPTION
Modify build.sh to perform a mostly self contained build of webrtc at
the tested commit id. Some pre-requisites must be installed before or
after a missing tool failure is encountered, e.g. pkg-config on mac or
webrtc/src/build/install-build-deps.sh on linux.

Tested: linux and mac builds worked from clean virtual machines. Demos
and tests passed.