### PR TITLE
Switch demos to use relative path to go-webrtc package

### DIFF
--- a/demo/chat/chat.go
+++ b/demo/chat/chat.go
@@ -12,7 +12,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/keroserene/go-webrtc"
+	"../../../go-webrtc"
 	"os"
 	"os/signal"
 	"strings"

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -14,7 +14,7 @@ package main
 import "C"
 import (
 	"fmt"
-	"github.com/keroserene/go-webrtc"
+	"../../go-webrtc"
 )
 
 func main() {


### PR DESCRIPTION
This is quite helpful when running demos from a fork. Let me know what you think.