### PR TITLE
Pass DataChannelInit options to CGO

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -101,7 +101,7 @@ func (c *DataChannel) Protocol() string {
 	return C.GoString(p)
 }
 
-func (c *DataChannel) MaxPacketLifeTime() uint {
+func (c *DataChannel) MaxRetransmitTime() uint {
 	return uint(C.CGO_Channel_MaxRetransmitTime(c.cgoChannel))
 }
 
@@ -127,7 +127,7 @@ func (c *DataChannel) BufferedAmount() int {
 
 type DataChannelInit struct {
 	Ordered           bool
-	MaxPacketLifeTime int
+	MaxRetransmitTime int
 	MaxRetransmits    int
 	Protocol          string
 	Negotiated        bool

--- a/datachannel.go
+++ b/datachannel.go
@@ -125,15 +125,13 @@ func (c *DataChannel) BufferedAmount() int {
 	return int(C.CGO_Channel_BufferedAmount(c.cgoChannel))
 }
 
-// TODO: Variadic options constructor, probably makes more sense for
-// CreateDataChannel in parent package PeerConnection.
-type Init struct {
+type DataChannelInit struct {
 	Ordered           bool
-	MaxPacketLifeTime uint
-	MaxRetransmits    uint
+	MaxPacketLifeTime int
+	MaxRetransmits    int
 	Protocol          string
 	Negotiated        bool
-	ID                uint
+	ID                int
 }
 
 //

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -1,9 +1,10 @@
 package webrtc
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestDataStateEnums(t *testing.T) {
@@ -25,7 +26,7 @@ func TestDataStateEnums(t *testing.T) {
 		So(c.Label(), ShouldEqual, "fake")
 		So(c.Ordered(), ShouldBeFalse)
 		So(c.Protocol(), ShouldEqual, "")
-		So(c.MaxPacketLifeTime(), ShouldEqual, 0)
+		So(c.MaxRetransmitTime(), ShouldEqual, 0)
 		So(c.MaxRetransmits(), ShouldEqual, 0)
 		So(c.Negotiated(), ShouldBeFalse)
 		So(c.ID(), ShouldEqual, 12345)

--- a/demo/chat/chat.go
+++ b/demo/chat/chat.go
@@ -12,10 +12,11 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/keroserene/go-webrtc"
 	"os"
 	"os/signal"
 	"strings"
+
+	"github.com/keroserene/go-webrtc"
 )
 
 var pc *webrtc.PeerConnection
@@ -234,7 +235,7 @@ func start(instigator bool) {
 	if instigator {
 		// Attempting to create the first datachannel triggers ICE.
 		fmt.Println("Initializing datachannel....")
-		dc, err = pc.CreateDataChannel("test", webrtc.Init{})
+		dc, err = pc.CreateDataChannel("test")
 		if nil != err {
 			fmt.Println("Unexpected failure creating Channel.")
 			return

--- a/peerconnection.cc
+++ b/peerconnection.cc
@@ -427,14 +427,14 @@ int CGO_SetConfiguration(CGO_Peer cgoPeer, CGO_Configuration* cgoConfig) {
 
 // PeerConnection::CreateDataChannel
 void* CGO_CreateDataChannel(CGO_Peer cgoPeer, char *label, CGO_DataChannelInit dict) {
-  auto cPeer = (Peer*)cgoPeer;
-  /* DataChannelInit *r = (DataChannelInit*)dict; */
-  // TODO: a real DataChannelInit config with correct fields.
   DataChannelInit config;
-  config.ordered = dict.ordered > 0;
-  /* config.maxRetransmitTime = dict.maxRetransmitTime; */
+  config.ordered = dict.ordered;
   config.maxRetransmits = dict.maxRetransmits;
+  config.maxRetransmitTime = dict.maxPacketLifeTime;
+  config.negotiated = dict.negotiated;
+  config.id = dict.id;
 
+  auto cPeer = (Peer*)cgoPeer;
   std::string l(label);
   auto channel = cPeer->pc_->CreateDataChannel(l, &config);
   if (NULL == channel) {

--- a/peerconnection.cc
+++ b/peerconnection.cc
@@ -430,7 +430,7 @@ void* CGO_CreateDataChannel(CGO_Peer cgoPeer, char *label, CGO_DataChannelInit d
   DataChannelInit config;
   config.ordered = dict.ordered;
   config.maxRetransmits = dict.maxRetransmits;
-  config.maxRetransmitTime = dict.maxPacketLifeTime;
+  config.maxRetransmitTime = dict.maxRetransmitTime;
   config.negotiated = dict.negotiated;
   config.id = dict.id;
 

--- a/peerconnection.cc
+++ b/peerconnection.cc
@@ -426,11 +426,15 @@ int CGO_SetConfiguration(CGO_Peer cgoPeer, CGO_Configuration* cgoConfig) {
 }
 
 // PeerConnection::CreateDataChannel
-void* CGO_CreateDataChannel(CGO_Peer cgoPeer, char *label, void *dict) {
+void* CGO_CreateDataChannel(CGO_Peer cgoPeer, char *label, CGO_DataChannelInit dict) {
   auto cPeer = (Peer*)cgoPeer;
-  DataChannelInit *r = (DataChannelInit*)dict;
+  /* DataChannelInit *r = (DataChannelInit*)dict; */
   // TODO: a real DataChannelInit config with correct fields.
   DataChannelInit config;
+  config.ordered = dict.ordered > 0;
+  /* config.maxRetransmitTime = dict.maxRetransmitTime; */
+  config.maxRetransmits = dict.maxRetransmits;
+
   std::string l(label);
   auto channel = cPeer->pc_->CreateDataChannel(l, &config);
   if (NULL == channel) {

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -335,10 +335,10 @@ func Ordered(ordered bool) func(*DataChannelInit) {
 	}
 }
 
-// MaxPacketLifeTime configures a DataChannels 'maxRetransmitTime' option.
-func MaxPacketLifeTime(maxPacketLifeTime int) func(*DataChannelInit) {
+// MaxRetransmitTime configures a DataChannels 'maxRetransmitTime' option.
+func MaxRetransmitTime(maxRetransmitTime int) func(*DataChannelInit) {
 	return func(i *DataChannelInit) {
-		i.MaxPacketLifeTime = maxPacketLifeTime
+		i.MaxRetransmitTime = maxRetransmitTime
 	}
 }
 
@@ -362,7 +362,7 @@ func (pc *PeerConnection) CreateDataChannel(label string, options ...func(*DataC
 	// These are the defaults taken from include/webrtc/api/datachannelinterface.h
 	init := DataChannelInit{
 		Ordered:           true,
-		MaxPacketLifeTime: -1,
+		MaxRetransmitTime: -1,
 		MaxRetransmits:    -1,
 		Negotiated:        false,
 		ID:                -1,
@@ -383,7 +383,7 @@ func (pc *PeerConnection) CreateDataChannel(label string, options ...func(*DataC
 	}
 	cfg.id = C.int(init.ID)
 	cfg.maxRetransmits = C.int(init.MaxRetransmits)
-	cfg.maxPacketLifeTime = C.int(init.MaxPacketLifeTime)
+	cfg.maxRetransmitTime = C.int(init.MaxRetransmitTime)
 
 	l := C.CString(label)
 	defer C.free(unsafe.Pointer(l))

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -333,7 +333,19 @@ func (pc *PeerConnection) CreateDataChannel(label string, dict Init) (
 	*DataChannel, error) {
 	l := C.CString(label)
 	defer C.free(unsafe.Pointer(l))
-	cDataChannel := C.CGO_CreateDataChannel(pc.cgoPeer, l, unsafe.Pointer(&dict))
+
+	cfg := C.CGO_DataChannelInit{
+		ordered:        0,
+		maxRetransmits: -1,
+	}
+
+	if dict.Ordered {
+		cfg.ordered = C.int(1)
+	}
+
+	cfg.maxRetransmits = C.int(dict.MaxRetransmits)
+
+	cDataChannel := C.CGO_CreateDataChannel(pc.cgoPeer, l, cfg)
 	if nil == cDataChannel {
 		return nil, errors.New("Failed to CreateDataChannel")
 	}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -329,21 +329,43 @@ exchange data.
 
 TODO: Implement the "negotiated" flag?
 */
-func (pc *PeerConnection) CreateDataChannel(label string, dict Init) (
+
+func Ordered(ordered bool) func(*DataChannelInit) {
+	return func(i *DataChannelInit) {
+		i.Ordered = ordered
+	}
+}
+
+func MaxRetransmits(maxRetransmits int) func(*DataChannelInit) {
+	return func(i *DataChannelInit) {
+		i.MaxRetransmits = maxRetransmits
+	}
+}
+
+func (pc *PeerConnection) CreateDataChannel(label string, options ...func(*DataChannelInit)) (
 	*DataChannel, error) {
 	l := C.CString(label)
 	defer C.free(unsafe.Pointer(l))
 
-	cfg := C.CGO_DataChannelInit{
-		ordered:        0,
-		maxRetransmits: -1,
+	init := DataChannelInit{
+		Ordered:           true,
+		MaxPacketLifeTime: -1,
+		MaxRetransmits:    -1,
+		Negotiated:        false,
+		ID:                -1,
 	}
 
-	if dict.Ordered {
+	for _, option := range options {
+		option(&init)
+	}
+
+	cfg := C.CGO_DataChannelInit{}
+
+	if init.Ordered {
 		cfg.ordered = C.int(1)
 	}
 
-	cfg.maxRetransmits = C.int(dict.MaxRetransmits)
+	cfg.maxRetransmits = C.int(init.MaxRetransmits)
 
 	cDataChannel := C.CGO_CreateDataChannel(pc.cgoPeer, l, cfg)
 	if nil == cDataChannel {

--- a/peerconnection.h
+++ b/peerconnection.h
@@ -19,7 +19,7 @@ extern "C" {
 
   typedef struct {
     int ordered;
-    int maxPacketLifeTime;
+    int maxRetransmitTime;
     int maxRetransmits;
     char *protocol;
     int negotiated;

--- a/peerconnection.h
+++ b/peerconnection.h
@@ -18,6 +18,12 @@ extern "C" {
   typedef const char* CGO_sdpString;
 
   typedef struct {
+    int ordered;
+    int maxRetransmitTime;
+    int maxRetransmits;
+  } CGO_DataChannelInit;
+
+  typedef struct {
     char **urls;
     int   numUrls;
 
@@ -66,7 +72,7 @@ extern "C" {
   int CGO_IceGatheringState(CGO_Peer);
   int CGO_SetConfiguration(CGO_Peer, CGO_Configuration*);
 
-  void* CGO_CreateDataChannel(CGO_Peer, char*, void*);
+  void* CGO_CreateDataChannel(CGO_Peer, char*, CGO_DataChannelInit);
 
   void CGO_Close(CGO_Peer);
 

--- a/peerconnection.h
+++ b/peerconnection.h
@@ -19,8 +19,11 @@ extern "C" {
 
   typedef struct {
     int ordered;
-    int maxRetransmitTime;
+    int maxPacketLifeTime;
     int maxRetransmits;
+    char *protocol;
+    int negotiated;
+    int id;
   } CGO_DataChannelInit;
 
   typedef struct {

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -1,9 +1,10 @@
 package webrtc
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestIceGatheringStateEnums(t *testing.T) {
@@ -239,7 +240,7 @@ func TestPeerConnection(t *testing.T) {
 			})
 
 			Convey("DataChannel", func() {
-				channel, err := alice.CreateDataChannel("test", Init{})
+				channel, err := alice.CreateDataChannel("test")
 				So(channel, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 				So(channel.Label(), ShouldEqual, "test")


### PR DESCRIPTION
This PR implements the passing of `DataChannelInit` options to the webrtc library allowing users to configure their DataChannels. 

This PR makes three breaking changes.

1. I have renamed `webrtc.Init` to `webrtc.DataChannelInit` which is the naming found within the webrtc library. 
2. I have renamed `MaxPacketLifeTime` to `MaxRetransmitTime` - again, this is the naming used inside of webrtc.
3. `peerconnection.CreateDataChannel()` no longer takes a `webrtc.Init{}` as an second argument. Instead it takes functional options. This gives us the following API:
```go
dc1 := peerconnection.CreateDataChannel() // Using reliable defaults
dc2 := peerconnection.CreateDataChannel(
  "some-label",
  webrtc.Ordered(false),
  webrtc.MaxRetransmits(0),
) // For unreliable messages
```

Thoughts? Personally I think this PR is a bit too big but I wanted to start a discussion with some code. These changes were trivial to make and so I am happy to pick it apart and create seperate pull requests if needed.