### PR TITLE
Add support for sending and receiving audio, and all that entails.

### DIFF
--- a/audiotrack.cc
+++ b/audiotrack.cc
@@ -1,0 +1,88 @@
+#include <_cgo_export.h>  // Allow calling certain Go functions.
+
+#include "audiotrack.h"
+
+#include "webrtc/api/mediastreaminterface.h"
+#include "webrtc/pc/mediastreamtrack.h"
+
+using namespace webrtc;
+
+class AudioTrack : public MediaStreamTrack<AudioTrackInterface> {
+ public:
+  explicit AudioTrack(std::string label, CGO_GoAudioSource source)
+    : MediaStreamTrack<AudioTrackInterface>(label)
+    , source(source) {}
+
+  virtual std::string kind() const override {
+    return kAudioKind;
+  }
+
+  virtual AudioSourceInterface* GetSource() const override {
+    return nullptr;
+  }
+
+  virtual void AddSink(AudioTrackSinkInterface* sink) override {
+    cgoAudioSourceAddSink(source, (CGO_AudioSink)sink);
+  }
+  virtual void RemoveSink(AudioTrackSinkInterface* sink) override {
+    cgoAudioSourceRemoveSink(source, (CGO_AudioSink)sink);
+  }
+
+  virtual bool GetSignalLevel(int* level) override { return false; }
+
+  virtual rtc::scoped_refptr<AudioProcessorInterface> GetAudioProcessor() override {
+    return nullptr;
+  }
+
+protected:
+  ~AudioTrack() {
+    cgoAudioSourceDestruct(source);
+  }
+
+private:
+  CGO_GoAudioSource source;
+};
+
+CGO_AudioTrack CGO_NewAudioTrack(const char* label, CGO_GoAudioSource source) {
+  return new rtc::RefCountedObject<AudioTrack>(label, source);
+}
+
+class AudioSink : public AudioTrackSinkInterface {
+public:
+	explicit AudioSink(CGO_GoAudioSink s) : s(s) {}
+
+	virtual void OnData(const void* audio_data,
+		                int bits_per_sample,
+		                int sample_rate,
+		                size_t number_of_channels,
+		                size_t number_of_frames) {
+		cgoAudioSinkOnData(
+			s,
+			(void*)audio_data,
+			bits_per_sample,
+			sample_rate,
+			(int)number_of_channels,
+			(int)number_of_frames
+		);
+	}
+
+	CGO_GoAudioSink s;
+};
+
+void CGO_AudioSinkOnData(CGO_AudioSink s, void* data, int bitsPerSample, int sampleRate, int numberOfChannels, int numberOfFrames) {
+	((AudioTrackSinkInterface*)s)->OnData(data, bitsPerSample, sampleRate, (size_t)numberOfChannels, (size_t)numberOfFrames);
+}
+
+CGO_AudioSink CGO_AudioTrack_AddSink(CGO_AudioTrack t, CGO_GoAudioSink gs) {
+  auto s = new AudioSink(gs);
+  ((AudioTrackInterface*)t)->AddSink(s);
+  return s;
+}
+
+CGO_GoAudioSink CGO_AudioTrack_RemoveSink(CGO_AudioTrack t, CGO_AudioSink cs) {
+  auto s = (AudioSink*)cs;
+  ((AudioTrackInterface*)t)->RemoveSink(s);
+  auto gs = s->s;
+  delete s;
+  return gs;
+}

--- a/audiotrack.go
+++ b/audiotrack.go
@@ -1,0 +1,142 @@
+package webrtc
+
+/*
+#include "mediastreamtrack.h"
+#include "audiotrack.h"
+*/
+import "C"
+import (
+	"math"
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+/*
+An AudioTrack can be obtained via NewAudioTrack (a local track) or via
+PeerConnection.OnAddTrack (a remote track).  Audio samples are provided or
+retrieved, respectively, via an AudioSource or AudioSink.
+*/
+type AudioTrack struct {
+	*mediaStreamTrack
+	t C.CGO_AudioTrack
+}
+
+func newAudioTrack(t C.CGO_AudioTrack) *AudioTrack {
+	return &AudioTrack{
+		mediaStreamTrack: newMediaStreamTrack(C.CGO_MediaStreamTrack(t)),
+		t:                t,
+	}
+}
+
+// NewAudioTrack creates a local audio track.
+func NewAudioTrack(label string, source AudioSource) *AudioTrack {
+	t := C.CGO_NewAudioTrack(C.CString(label), C.CGO_GoAudioSource(audioSources.Set(source)))
+	return newAudioTrack(t)
+}
+
+func (t *AudioTrack) AddSink(s AudioSink) {
+	cAudioSinksMu.Lock()
+	defer cAudioSinksMu.Unlock()
+
+	if _, ok := cAudioSinks[s]; ok {
+		panic("AudioSink already added")
+	}
+	csink := C.CGO_AudioTrack_AddSink(t.t, C.CGO_GoAudioSink(audioSinks.Set(s)))
+	cAudioSinks[s] = csink
+}
+
+func (t *AudioTrack) RemoveSink(s AudioSink) {
+	cAudioSinksMu.Lock()
+	defer cAudioSinksMu.Unlock()
+
+	if csink, ok := cAudioSinks[s]; ok {
+		audioSinks.Delete(int(C.CGO_AudioTrack_RemoveSink(t.t, csink)))
+		delete(cAudioSinks, s)
+	}
+}
+
+var (
+	audioSources = NewCGOMap()
+	audioSinks   = NewCGOMap()
+
+	cAudioSinksMu sync.Mutex
+	cAudioSinks   = map[AudioSink]C.CGO_AudioSink{}
+)
+
+// An AudioSource pushes audio to the AudioSinks that are added to it.
+type AudioSource interface {
+	AddAudioSink(AudioSink)
+	RemoveAudioSink(AudioSink)
+}
+
+// An AudioSink receives audio, typically from an AudioSource.
+type AudioSink interface {
+	/*
+		OnAudioData is called when new audio data is available.
+		len(data) == numberOfChannels; len(data[i]) is the same for all i.
+	*/
+	OnAudioData(data [][]float64, sampleRate float64)
+}
+
+//export cgoAudioSourceAddSink
+func cgoAudioSourceAddSink(source C.CGO_GoAudioSource, sink C.CGO_AudioSink) {
+	audioSources.Get(int(source)).(AudioSource).AddAudioSink(cAudioSink{sink})
+}
+
+//export cgoAudioSourceRemoveSink
+func cgoAudioSourceRemoveSink(source C.CGO_GoAudioSource, sink C.CGO_AudioSink) {
+	audioSources.Get(int(source)).(AudioSource).RemoveAudioSink(cAudioSink{sink})
+}
+
+//export cgoAudioSourceDestruct
+func cgoAudioSourceDestruct(source C.CGO_GoAudioSource) {
+	audioSources.Delete(int(source))
+}
+
+type cAudioSink struct {
+	s C.CGO_AudioSink
+}
+
+func (s cAudioSink) OnAudioData(data [][]float64, sampleRate float64) {
+	bitsPerSample := 16
+	numberOfChannels := len(data)
+	numberOfFrames := len(data[0])
+	buf := make([]int16, numberOfChannels*numberOfFrames*bitsPerSample/2)
+	i := 0
+	for j := range data[0] {
+		for _, ch := range data {
+			buf[i] = int16(ch[j] * float64(math.MaxInt16))
+			i++
+		}
+	}
+	C.CGO_AudioSinkOnData(s.s, unsafe.Pointer(&buf[0]), C.int(bitsPerSample), C.int(sampleRate), C.int(numberOfChannels), C.int(numberOfFrames))
+}
+
+//export cgoAudioSinkOnData
+func cgoAudioSinkOnData(s C.CGO_GoAudioSink, audioData unsafe.Pointer, bitsPerSample, sampleRate, numberOfChannels, numberOfFrames int) {
+	if bitsPerSample != 16 {
+		panic("expected 16 bits per sample")
+	}
+
+	var buf []int16
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
+	sh.Data = uintptr(audioData)
+	sh.Len = numberOfChannels * numberOfFrames
+	sh.Cap = sh.Len
+
+	data := make([][]float64, numberOfChannels)
+	for i := range data {
+		data[i] = make([]float64, numberOfFrames)
+	}
+
+	i := 0
+	for j := range data[0] {
+		for _, ch := range data {
+			ch[j] = float64(buf[i]) / float64(math.MaxInt16)
+			i++
+		}
+	}
+
+	audioSinks.Get(int(s)).(AudioSink).OnAudioData(data, float64(sampleRate))
+}

--- a/audiotrack.h
+++ b/audiotrack.h
@@ -1,0 +1,30 @@
+#ifndef _C_AUDIOTRACK_H
+#define _C_AUDIOTRACK_H
+
+#define WEBRTC_POSIX 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_AudioTrack; // webrtc::AudioTrackInterface*
+  typedef int CGO_GoAudioSource; // key into Go audioSourceMap
+  typedef int CGO_GoAudioSink; // key into Go audioSinkMap
+  typedef void* CGO_AudioSink; // webrtc::AudioTrackSinkInterface
+
+  CGO_AudioTrack CGO_NewAudioTrack(const char* label, CGO_GoAudioSource source);
+
+  void CGO_AudioSinkOnData(CGO_AudioSink s, void* data, int bitsPerSample, int sampleRate, int numberOfChannels, int numberOfFrames);
+
+  CGO_AudioSink CGO_AudioTrack_AddSink(CGO_AudioTrack, CGO_GoAudioSink);
+  CGO_GoAudioSink CGO_AudioTrack_RemoveSink(CGO_AudioTrack, CGO_AudioSink);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_AUDIOTRACK_H

--- a/demo/beep/beep.go
+++ b/demo/beep/beep.go
@@ -1,0 +1,138 @@
+/*
+WebRTC audio bee demo server.
+See beep.html for the client.
+
+To use, `go run beep.go`, then open beep.html in a browser.
+This server will send a tone to the browser, which will play it.
+*/
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/keroserene/go-webrtc"
+	"golang.org/x/net/websocket"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	webrtc.SetLoggingVerbosity(1)
+
+	http.Handle("/ws", websocket.Handler(handleWebSocket))
+	log.Fatal(http.ListenAndServe(":49372", nil))
+}
+
+func handleWebSocket(ws *websocket.Conn) {
+	pc, err := webrtc.NewPeerConnection(webrtc.NewConfiguration())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	beep := &beep{}
+	pc.AddTrack(webrtc.NewAudioTrack("beep-audio", beep), nil)
+	go beep.run()
+
+	pc.OnIceCandidate = func(c webrtc.IceCandidate) {
+		if err := websocket.JSON.Send(ws, c); err != nil {
+			log.Println(err)
+			return
+		}
+	}
+
+	for {
+		var msg struct {
+			Type string
+			Body json.RawMessage
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			if err != io.EOF {
+				log.Println(err)
+			}
+			return
+		}
+
+		switch msg.Type {
+		case "offer":
+			offer := webrtc.DeserializeSessionDescription(string(msg.Body))
+			if err := pc.SetRemoteDescription(offer); err != nil {
+				log.Println(err)
+				return
+			}
+			answer, err := pc.CreateAnswer()
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if err := pc.SetLocalDescription(answer); err != nil {
+				log.Println(err)
+				return
+			}
+			if err := websocket.JSON.Send(ws, answer); err != nil {
+				log.Println(err)
+				return
+			}
+		case "icecandidate":
+			c := webrtc.DeserializeIceCandidate(string(msg.Body))
+			if err := pc.AddIceCandidate(*c); err != nil {
+				log.Println(err)
+			}
+		default:
+			log.Println("unexpected message type:", msg.Type)
+		}
+	}
+}
+
+type beep struct {
+	sync.Mutex
+	sinks []webrtc.AudioSink
+}
+
+func (b *beep) AddAudioSink(s webrtc.AudioSink) {
+	b.Lock()
+	b.sinks = append(b.sinks, s)
+	b.Unlock()
+}
+
+func (b *beep) RemoveAudioSink(s webrtc.AudioSink) {
+	b.Lock()
+	defer b.Unlock()
+	for i, s2 := range b.sinks {
+		if s2 == s {
+			b.sinks = append(b.sinks[:i], b.sinks[i+1:]...)
+		}
+	}
+}
+
+func (b *beep) run() {
+	const (
+		sampleRate     = 48000
+		chunkRate      = 100
+		numberOfFrames = sampleRate / chunkRate
+		toneFrequency  = 256
+	)
+	data := [][]float64{make([]float64, numberOfFrames)}
+	count := 0
+	x := 0.04
+	for next := time.Now(); ; next = next.Add(time.Second / chunkRate) {
+		time.Sleep(next.Sub(time.Now()))
+
+		for i := range data[0] {
+			if count%(sampleRate/toneFrequency/2) == 0 {
+				x = -x
+			}
+			data[0][i] = x
+			count++
+		}
+
+		b.Lock()
+		for _, sink := range b.sinks {
+			sink.OnAudioData(data, sampleRate)
+		}
+		b.Unlock()
+	}
+}

--- a/demo/beep/beep.html
+++ b/demo/beep/beep.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <script src="beep.js"></script>
+</head>
+<body>
+  <h1>go-webrtc audio beep demo</h1>
+  <audio id="audio" autoplay />
+</body>
+</html>

--- a/demo/beep/beep.js
+++ b/demo/beep/beep.js
@@ -1,0 +1,53 @@
+// WebRTC audio echo client
+// See echo.go for the server.
+
+// Chrome / Firefox compatibility
+window.RTCPeerConnection = window.RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection;
+
+var ws;
+var pc;
+
+window.onload = () => {
+	openWebSocket()
+	.then(() => {
+		pc = new window.RTCPeerConnection();
+		pc.onaddstream = evt => {
+			console.info("onaddstream", evt.stream);
+			document.getElementById('audio').srcObject = evt.stream;
+		};
+		pc.onicecandidate = evt => {
+			if (evt.candidate) {
+				ws.send(JSON.stringify({type: "icecandidate", body: evt.candidate}));
+			}
+		};
+		return pc.createOffer({offerToReceiveAudio: true})
+		.then(offer => {
+			ws.send(JSON.stringify({type: "offer", body: offer}));
+			return pc.setLocalDescription(offer);
+		});
+	})
+	.catch(err => console.error('unhandled error:', err));
+}
+
+function openWebSocket() {
+	return new Promise((resolve, reject) => {
+		ws = new WebSocket('ws://localhost:49372/ws');
+		ws.onopen = () => {
+			console.info("WS OPENED");
+			resolve();
+		};
+		ws.onerror = err => {
+			console.error('websocket error:', err);
+			reject();
+		};
+		ws.onmessage = evt => {
+			let msg = JSON.parse(evt.data);
+			if (msg.sdp) {
+				pc.setRemoteDescription(msg);
+			} else {
+				pc.addIceCandidate(msg);
+			}
+		};
+		ws.onclose = () => console.info("WS CLOSED");
+	});
+}

--- a/demo/echo/echo.go
+++ b/demo/echo/echo.go
@@ -1,0 +1,124 @@
+/*
+WebRTC audio echo demo server.
+See echo.html for the client.
+
+To use, `go run echo.go`, then open echo.html in a browser.
+You may want to wear headphones or turn your volume low,
+because there will be some audio feedback (much of which should
+be removed by echo cancellation).
+*/
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/keroserene/go-webrtc"
+	"golang.org/x/net/websocket"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	webrtc.SetLoggingVerbosity(1)
+
+	http.Handle("/ws", websocket.Handler(handleWebSocket))
+	log.Fatal(http.ListenAndServe(":49372", nil))
+}
+
+func handleWebSocket(ws *websocket.Conn) {
+	pc, err := webrtc.NewPeerConnection(webrtc.NewConfiguration())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pc.OnIceCandidate = func(c webrtc.IceCandidate) {
+		if err := websocket.JSON.Send(ws, c); err != nil {
+			log.Println(err)
+			return
+		}
+	}
+
+	pc.OnAddTrack = func(r *webrtc.RtpReceiver, s []*webrtc.MediaStream) {
+		echo := &echo{}
+		r.Track().(*webrtc.AudioTrack).AddSink(echo)
+		pc.AddTrack(webrtc.NewAudioTrack("audio-echo", echo), nil)
+
+		// A much simpler way to echo audio (but less useful
+		// for demonstrative purposes) is to just:
+		// pc.AddTrack(r.Track(), s)
+	}
+
+	for {
+		var msg struct {
+			Type string
+			Body json.RawMessage
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			if err != io.EOF {
+				log.Println(err)
+			}
+			return
+		}
+
+		switch msg.Type {
+		case "offer":
+			offer := webrtc.DeserializeSessionDescription(string(msg.Body))
+			if err := pc.SetRemoteDescription(offer); err != nil {
+				log.Println(err)
+				return
+			}
+			answer, err := pc.CreateAnswer()
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if err := pc.SetLocalDescription(answer); err != nil {
+				log.Println(err)
+				return
+			}
+			if err := websocket.JSON.Send(ws, answer); err != nil {
+				log.Println(err)
+				return
+			}
+		case "icecandidate":
+			c := webrtc.DeserializeIceCandidate(string(msg.Body))
+			if err := pc.AddIceCandidate(*c); err != nil {
+				log.Println(err)
+			}
+		default:
+			log.Println("unexpected message type:", msg.Type)
+		}
+	}
+}
+
+type echo struct {
+	sync.Mutex
+	sinks []webrtc.AudioSink
+}
+
+func (e *echo) AddAudioSink(s webrtc.AudioSink) {
+	e.Lock()
+	defer e.Unlock()
+	e.sinks = append(e.sinks, s)
+}
+
+func (e *echo) RemoveAudioSink(s webrtc.AudioSink) {
+	e.Lock()
+	defer e.Unlock()
+	for i, s2 := range e.sinks {
+		if s2 == s {
+			e.sinks = append(e.sinks[:i], e.sinks[i+1:]...)
+		}
+	}
+}
+
+func (e *echo) OnAudioData(data [][]float64, sampleRate float64) {
+	e.Lock()
+	defer e.Unlock()
+	for _, s := range e.sinks {
+		s.OnAudioData(data, sampleRate)
+	}
+}

--- a/demo/echo/echo.html
+++ b/demo/echo/echo.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <script src="echo.js"></script>
+</head>
+<body>
+  <h1>go-webrtc audio echo demo</h1>
+  <audio id="audio" autoplay />
+</body>
+</html>

--- a/demo/echo/echo.js
+++ b/demo/echo/echo.js
@@ -1,0 +1,57 @@
+// WebRTC audio echo client
+// See echo.go for the server.
+
+// Chrome / Firefox compatibility
+window.RTCPeerConnection = window.RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection;
+
+var ws;
+var stream;
+var pc;
+
+window.onload = () => {
+	navigator.mediaDevices.getUserMedia({audio: true})
+	.then(s => stream = s)
+	.then(() => openWebSocket())
+	.then(() => {
+		pc = new window.RTCPeerConnection();
+		pc.addStream(stream);
+		pc.onaddstream = evt => {
+			console.info("onaddstream", evt.stream);
+			document.getElementById('audio').srcObject = evt.stream;
+		};
+		pc.onicecandidate = evt => {
+			if (evt.candidate) {
+				ws.send(JSON.stringify({type: "icecandidate", body: evt.candidate}));
+			}
+		};
+		return pc.createOffer()
+		.then(offer => {
+			ws.send(JSON.stringify({type: "offer", body: offer}));
+			return pc.setLocalDescription(offer);
+		});
+	})
+	.catch(err => console.error('unhandled error:', err));
+}
+
+function openWebSocket() {
+	return new Promise((resolve, reject) => {
+		ws = new WebSocket('ws://localhost:49372/ws');
+		ws.onopen = () => {
+			console.info("WS OPENED");
+			resolve();
+		};
+		ws.onerror = err => {
+			console.error('websocket error:', err);
+			reject();
+		};
+		ws.onmessage = evt => {
+			let msg = JSON.parse(evt.data);
+			if (msg.sdp) {
+				pc.setRemoteDescription(msg);
+			} else {
+				pc.addIceCandidate(msg);
+			}
+		};
+		ws.onclose = () => console.info("WS CLOSED");
+	});
+}

--- a/eventlistener.cc
+++ b/eventlistener.cc
@@ -1,0 +1,35 @@
+#include <_cgo_export.h>  // Allow calling certain Go functions.
+
+#include "eventlistener.h"
+
+#include "webrtc/api/mediastreaminterface.h"
+
+using namespace webrtc;
+
+class Observer : public ObserverInterface {
+public:
+  Observer(NotifierInterface* n, CGO_EventCallback c)
+    : n(n), c(c) {
+    n->RegisterObserver(this);
+  }
+
+  ~Observer() {
+    n->UnregisterObserver(this);
+  }
+
+  void OnChanged() override {
+    cgoObserverOnChanged(c);
+  }
+
+private:
+  NotifierInterface* n;
+  CGO_EventCallback c;
+};
+
+CGO_Observer CGO_NewObserver(CGO_Notifier n, CGO_EventCallback c) {
+  return new Observer((NotifierInterface*)n, c);
+}
+
+void CGO_DeleteObserver(CGO_Observer o) {
+  delete (Observer*)o;
+}

--- a/eventlistener.go
+++ b/eventlistener.go
@@ -1,0 +1,34 @@
+package webrtc
+
+/*
+#include "eventlistener.h"
+*/
+import "C"
+
+type EventListener struct {
+	o C.CGO_Observer
+	c int
+}
+
+func newEventListener(n C.CGO_Notifier, f func()) *EventListener {
+	c := eventCallbacks.Set(f)
+	return &EventListener{
+		o: C.CGO_NewObserver(n, C.CGO_EventCallback(c)),
+		c: c,
+	}
+}
+
+var eventCallbacks = NewCGOMap()
+
+func (e *EventListener) Cancel() {
+	if e.o != nil {
+		C.CGO_DeleteObserver(e.o)
+		e.o = nil
+		eventCallbacks.Delete(e.c)
+	}
+}
+
+//export cgoObserverOnChanged
+func cgoObserverOnChanged(l C.CGO_EventCallback) {
+	eventCallbacks.Get(int(l)).(func())()
+}

--- a/eventlistener.h
+++ b/eventlistener.h
@@ -1,0 +1,25 @@
+#ifndef _C_EVENTLISTENER_H
+#define _C_EVENTLISTENER_H
+
+#define WEBRTC_POSIX 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_Notifier; // webrtc::NotifierInterface*
+  typedef void* CGO_Observer; // webrtc::ObserverInterface*
+  typedef int CGO_EventCallback; // key into Go eventCallbacks
+
+  CGO_Observer CGO_NewObserver(CGO_Notifier, CGO_EventCallback);
+  void CGO_DeleteObserver(CGO_Observer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_EVENTLISTENER_H

--- a/fauxaudiodevicemodule.cc
+++ b/fauxaudiodevicemodule.cc
@@ -1,0 +1,22 @@
+#include "fauxaudiodevicemodule.hpp"
+
+#include "webrtc/base/refcount.h"
+
+int32_t FauxAudioDeviceModule::RegisterAudioCallback(webrtc::AudioTransport* audio_callback) {
+  rtc::CritScope cs(&crit_);
+  audio_callback_ = audio_callback;
+  return 0;
+}
+
+void FauxAudioDeviceModule::Pull(uint16_t* audioSamples, size_t nSamples, uint32_t samplesPerSec) {
+  rtc::CritScope cs(&crit_);
+  if (!audio_callback_) {
+    return;
+  }
+  size_t nSamplesOut = 0;
+  int64_t elapsed_time_ms = 0;
+  int64_t ntp_time_ms = 0;
+  audio_callback_->NeedMorePlayData(nSamples, 2, 1, samplesPerSec,
+                                    audioSamples, nSamplesOut,
+                                    &elapsed_time_ms, &ntp_time_ms);
+}

--- a/fauxaudiodevicemodule.hpp
+++ b/fauxaudiodevicemodule.hpp
@@ -1,0 +1,33 @@
+#ifndef FAUXAUDIODEVICEMODULE_H_
+#define FAUXAUDIODEVICEMODULE_H_
+
+#include "webrtc/base/criticalsection.h"
+#include "webrtc/modules/audio_device/include/fake_audio_device.h"
+
+/*
+FauxAudioDeviceModule drives the mechanism for receiving remote audio tracks by
+having its Pull method called periodically (from Go, because I couldn't get
+threading to compile in C++).  It does not do the other thing that an
+AudioDeviceModule is intended to do, which is to push recorded audio, because,
+strangely, pushing any such audio causes it to be interleaved with audio data
+from other sent tracks, corrupting it on the receiving end.
+
+This feels hackish.  Maybe there is a better way to do it.
+*/
+class FauxAudioDeviceModule : public webrtc::FakeAudioDeviceModule {
+ public:
+  explicit FauxAudioDeviceModule() : audio_callback_(nullptr) {}
+
+  int32_t RegisterAudioCallback(webrtc::AudioTransport* audio_callback) override;
+
+  void Pull(uint16_t* audioSamples, size_t nSamples, uint32_t samplesPerSec);
+
+ protected:
+  virtual ~FauxAudioDeviceModule() {}
+
+ private:
+  webrtc::AudioTransport* audio_callback_;
+  rtc::CriticalSection crit_;
+};
+
+#endif  // FAUXAUDIODEVICEMODULE_H_

--- a/mediastream.cc
+++ b/mediastream.cc
@@ -1,0 +1,17 @@
+#include "mediastream.h"
+
+#include "webrtc/api/mediastreaminterface.h"
+
+CGO_AudioTrack* CGO_MediaStream_GetAudioTracks(CGO_MediaStream s, int* n) {
+	auto tracks = ((webrtc::MediaStreamInterface*)s)->GetAudioTracks();
+	*n = tracks.size();
+	auto ctracks = (CGO_AudioTrack*)malloc(*n * sizeof(CGO_AudioTrack*));
+	for (int i = 0; i < *n; ++i) {
+		ctracks[i] = tracks[i].release();
+	}
+	return ctracks;
+}
+
+void CGO_MediaStream_AddAudioTrack(CGO_MediaStream s, CGO_AudioTrack t) {
+	((webrtc::MediaStreamInterface*)s)->AddTrack((webrtc::AudioTrackInterface*)t);
+}

--- a/mediastream.go
+++ b/mediastream.go
@@ -1,0 +1,50 @@
+package webrtc
+
+/*
+#include "refptr.h"
+#include "mediastream.h"
+#include "peerconnection.h"
+
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+type MediaStream struct {
+	p *refptr
+	s C.CGO_MediaStream
+}
+
+func newMediaStream(s C.CGO_MediaStream) *MediaStream {
+	return &MediaStream{
+		p: newRefPtr(C.CGO_RefPtr(s)),
+		s: s,
+	}
+}
+
+// TODO: Factor pc_factory out of Peer (and make it a single global instance?)
+func (pc *PeerConnection) NewMediaStream(label string) *MediaStream {
+	s := C.CGO_NewMediaStream(pc.cgoPeer, C.CString(label))
+	return newMediaStream(s)
+}
+
+func (s *MediaStream) GetAudioTracks() []*AudioTrack {
+	var n C.int
+	ctracks := uintptr(unsafe.Pointer(C.CGO_MediaStream_GetAudioTracks(s.s, &n)))
+	tracks := make([]*AudioTrack, n)
+	for i := range tracks {
+		t := *(*C.CGO_AudioTrack)(unsafe.Pointer(ctracks + uintptr(i)))
+		tracks[i] = newAudioTrack(t)
+	}
+	C.free(unsafe.Pointer(ctracks))
+	return tracks
+}
+
+func (s *MediaStream) AddTrack(t MediaStreamTrack) {
+	switch t := t.(type) {
+	case *AudioTrack:
+		C.CGO_MediaStream_AddAudioTrack(s.s, t.t)
+	default:
+		panic("unknown track type")
+	}
+}

--- a/mediastream.h
+++ b/mediastream.h
@@ -1,0 +1,25 @@
+#ifndef _C_MEDIASTREAM_H_
+#define _C_MEDIASTREAM_H_
+
+#define WEBRTC_POSIX 1
+
+#include "audiotrack.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_MediaStream; // webrtc::MediaStreamInterface*
+
+  CGO_AudioTrack* CGO_MediaStream_GetAudioTracks(CGO_MediaStream, int*);
+  void CGO_MediaStream_AddAudioTrack(CGO_MediaStream, CGO_AudioTrack);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_MEDIASTREAM_H_

--- a/mediastreamtrack.cc
+++ b/mediastreamtrack.cc
@@ -1,0 +1,23 @@
+#include <_cgo_export.h>  // Allow calling certain Go functions.
+
+#include "mediastreamtrack.h"
+
+#include "webrtc/api/mediastreaminterface.h"
+
+using namespace webrtc;
+
+const char* CGO_MediaStreamTrack_ID(CGO_MediaStreamTrack t) {
+	return ((MediaStreamTrackInterface*)t)->id().c_str();
+}
+
+bool CGO_MediaStreamTrack_Enabled(CGO_MediaStreamTrack t) {
+	return ((MediaStreamTrackInterface*)t)->enabled();
+}
+
+void CGO_MediaStreamTrack_SetEnabled(CGO_MediaStreamTrack t, bool x) {
+	((MediaStreamTrackInterface*)t)->set_enabled(x);
+}
+
+bool CGO_MediaStreamTrack_Ended(CGO_MediaStreamTrack t) {
+	return ((MediaStreamTrackInterface*)t)->state() == MediaStreamTrackInterface::TrackState::kEnded;
+}

--- a/mediastreamtrack.go
+++ b/mediastreamtrack.go
@@ -1,0 +1,64 @@
+package webrtc
+
+/*
+#include "eventlistener.h"
+#include "refptr.h"
+#include "mediastreamtrack.h"
+*/
+import "C"
+
+// A MediaStreamTrack is either an *AudioTrack or a *VideoTrack.
+type MediaStreamTrack interface {
+	ID() string
+	Enabled() bool
+	SetEnabled(bool)
+	Ended() bool
+	OnEnded(func()) *EventListener
+
+	cgo_MediaStreamTrack() C.CGO_MediaStreamTrack
+}
+
+// A mediaStreamTrack is the common implementation shared by AudioTrack and VideoTrack.
+type mediaStreamTrack struct {
+	p *refptr
+	t C.CGO_MediaStreamTrack
+}
+
+func newMediaStreamTrack(t C.CGO_MediaStreamTrack) *mediaStreamTrack {
+	return &mediaStreamTrack{
+		p: newRefPtr(C.CGO_RefPtr(t)),
+		t: t,
+	}
+}
+
+func (t *mediaStreamTrack) cgo_MediaStreamTrack() C.CGO_MediaStreamTrack {
+	return t.t
+}
+
+func (t *mediaStreamTrack) ID() string {
+	return C.GoString(C.CGO_MediaStreamTrack_ID(t.t))
+}
+
+func (t *mediaStreamTrack) Enabled() bool {
+	return bool(C.CGO_MediaStreamTrack_Enabled(t.t))
+}
+
+func (t *mediaStreamTrack) SetEnabled(x bool) {
+	C.CGO_MediaStreamTrack_SetEnabled(t.t, C.bool(x))
+}
+
+func (t *mediaStreamTrack) Ended() bool {
+	return bool(C.CGO_MediaStreamTrack_Ended(t.t))
+}
+
+func (t *mediaStreamTrack) OnEnded(f func()) *EventListener {
+	var e *EventListener
+	e = newEventListener(C.CGO_Notifier(t.t), func() {
+		if t.Ended() {
+			f()
+			// Once a track has ended, it will never become live again.
+			e.Cancel()
+		}
+	})
+	return e
+}

--- a/mediastreamtrack.h
+++ b/mediastreamtrack.h
@@ -1,0 +1,27 @@
+#ifndef _C_MEDIASTREAMTRACK_H_
+#define _C_MEDIASTREAMTRACK_H_
+
+#define WEBRTC_POSIX 1
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_MediaStreamTrack; // webrtc::MediaStreamTrackInterface*
+
+  const char* CGO_MediaStreamTrack_ID(CGO_MediaStreamTrack);
+  bool CGO_MediaStreamTrack_Enabled(CGO_MediaStreamTrack);
+  void CGO_MediaStreamTrack_SetEnabled(CGO_MediaStreamTrack, bool);
+  bool CGO_MediaStreamTrack_Ended(CGO_MediaStreamTrack);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_MEDIASTREAMTRACK_H_

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -38,12 +38,14 @@ package webrtc
 #cgo darwin,amd64 pkg-config: webrtc-darwin-amd64.pc
 #include <stdlib.h>  // Needed for C.free
 #include "peerconnection.h"
+#include "rtpreceiver.h"
 #include "ctestenums.h"
 */
 import "C"
 import (
 	"errors"
 	"fmt"
+	"time"
 	"unsafe"
 )
 
@@ -127,6 +129,7 @@ type PeerConnection struct {
 
 	// Event handlers
 	OnNegotiationNeeded        func()
+	OnAddTrack                 func(*RtpReceiver, []*MediaStream)
 	OnIceCandidate             func(IceCandidate)
 	OnIceCandidateError        func()
 	OnIceComplete              func() // Possibly to be removed.
@@ -165,7 +168,28 @@ func NewPeerConnection(config *Configuration) (*PeerConnection, error) {
 		return nil, errors.New("PeerConnection: could not create from config.")
 	}
 	INFO.Println("Created PeerConnection: ", pc, pc.cgoPeer)
+	go pc.pullAudio()
 	return pc, nil
+}
+
+/*
+The webrtc.org mechanism for decoding audio data and passing it to audio tracks
+is driven by an audio device periodically requesting audio for playout.
+Instead of requiring a real audio device, we implement this mechanism here.
+*/
+func (pc *PeerConnection) pullAudio() {
+	const (
+		samplesPerSec = 48000
+		pullsPerSec   = 100
+	)
+	audioSamples := [samplesPerSec / pullsPerSec]uint16{}
+
+	next := time.Now()
+	for {
+		C.CGO_PullAudio(pc.cgoPeer, (*C.uint16_t)(&audioSamples[0]), C.int(len(audioSamples)), samplesPerSec)
+		next = next.Add(time.Second / pullsPerSec)
+		time.Sleep(next.Sub(time.Now()))
+	}
 }
 
 //
@@ -323,6 +347,22 @@ func (pc *PeerConnection) SetConfiguration(config Configuration) error {
 	return nil
 }
 
+func (pc *PeerConnection) AddTrack(t MediaStreamTrack, s []*MediaStream) *RtpSender {
+	var sp *C.CGO_MediaStream
+	if len(s) > 0 {
+		ss := make([]C.CGO_MediaStream, len(s))
+		for i, s := range s {
+			ss[i] = s.s
+		}
+		sp = &ss[0]
+	}
+	return newRtpSender(C.CGO_PeerConnection_AddTrack(pc.cgoPeer, t.cgo_MediaStreamTrack(), sp, C.int(len(s))))
+}
+
+func (pc *PeerConnection) RemoveTrack(s *RtpSender) {
+	C.CGO_PeerConnection_RemoveTrack(pc.cgoPeer, s.s)
+}
+
 /*
 Create and return a DataChannel.
 
@@ -368,6 +408,22 @@ func cgoOnSignalingStateChange(p int, s SignalingState) {
 	pc := PCMap.Get(p).(*PeerConnection)
 	if nil != pc.OnSignalingStateChange {
 		pc.OnSignalingStateChange(s)
+	}
+}
+
+//export cgoOnAddTrack
+func cgoOnAddTrack(p int, r C.CGO_RtpReceiver, s *C.CGO_MediaStream, ns int) {
+	INFO.Println("fired OnAddTrack: ", p, r, s, ns)
+	pc := PCMap.Get(p).(*PeerConnection)
+	receiver := newRtpReceiver(r)
+	streams := make([]*MediaStream, ns)
+	sp := uintptr(unsafe.Pointer(s))
+	for i := range streams {
+		s := *(*C.CGO_MediaStream)(unsafe.Pointer(sp + uintptr(i)))
+		streams[i] = newMediaStream(s)
+	}
+	if nil != pc.OnAddTrack {
+		pc.OnAddTrack(receiver, streams)
 	}
 }
 

--- a/peerconnection.h
+++ b/peerconnection.h
@@ -3,6 +3,12 @@
 
 #define WEBRTC_POSIX 1
 
+#include <stdint.h>
+
+#include "mediastreamtrack.h"
+#include "mediastream.h"
+#include "rtpsender.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,6 +55,8 @@ extern "C" {
 
   int CGO_CreatePeerConnection(CGO_Peer, CGO_Configuration*);
 
+  void CGO_PullAudio(CGO_Peer, uint16_t*, int, uint32_t);
+
   CGO_sdpString CGO_CreateOffer(CGO_Peer);
   CGO_sdpString CGO_CreateAnswer(CGO_Peer);
 
@@ -66,7 +74,12 @@ extern "C" {
   int CGO_IceGatheringState(CGO_Peer);
   int CGO_SetConfiguration(CGO_Peer, CGO_Configuration*);
 
+  CGO_RtpSender CGO_PeerConnection_AddTrack(CGO_Peer, CGO_MediaStreamTrack, CGO_MediaStream*, int);
+  void CGO_PeerConnection_RemoveTrack(CGO_Peer, CGO_RtpSender);
   void* CGO_CreateDataChannel(CGO_Peer, char*, void*);
+
+  // TODO: Move to mediastream.cc (when pc_factory is factored out of Peer).
+  CGO_MediaStream CGO_NewMediaStream(CGO_Peer cgoPeer, const char* label);
 
   void CGO_Close(CGO_Peer);
 

--- a/refptr.cc
+++ b/refptr.cc
@@ -1,0 +1,7 @@
+#include "refptr.h"
+
+#include "webrtc/base/refcount.h"
+
+void CGO_RefPtr_Release(CGO_RefPtr p) {
+	((rtc::RefCountInterface*)p)->Release();
+}

--- a/refptr.go
+++ b/refptr.go
@@ -1,0 +1,27 @@
+package webrtc
+
+/*
+#include "refptr.h"
+*/
+import "C"
+import "runtime"
+
+/*
+refptr holds a reference counted pointer and decrements its reference count
+when the refptr is garbage collected.  It is roughly the equivalent of
+rtc::scoped_refptr, except it doesn't increment the reference count.
+*/
+type refptr struct{}
+
+/*
+newRefPtr returns a refptr that, upon being garbage collected, decrements p's
+reference count.  p must already have its reference count incremented before
+being passed to newRefPtr, for example by calling scoped_refptr::release().
+*/
+func newRefPtr(p C.CGO_RefPtr) *refptr {
+	rp := &refptr{}
+	runtime.SetFinalizer(rp, func(*refptr) {
+		C.CGO_RefPtr_Release(p)
+	})
+	return rp
+}

--- a/refptr.h
+++ b/refptr.h
@@ -1,0 +1,20 @@
+#ifndef _C_REFPTR_H_
+#define _C_REFPTR_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_RefPtr; // rtc::RefCountInterface*
+
+  void CGO_RefPtr_Release(CGO_RefPtr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_REFPTR_H_

--- a/rtpreceiver.cc
+++ b/rtpreceiver.cc
@@ -1,0 +1,9 @@
+#include "rtpreceiver.h"
+
+#include "webrtc/api/rtpreceiverinterface.h"
+
+CGO_MediaStreamTrack CGO_RtpReceiver_Track(CGO_RtpReceiver r, bool* isAudio) {
+	auto t = ((webrtc::RtpReceiverInterface*)r)->track().release();
+	*isAudio = t->kind() == "audio";
+	return t;
+}

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -1,0 +1,29 @@
+package webrtc
+
+/*
+#include "refptr.h"
+#include "rtpreceiver.h"
+#include "audiotrack.h"
+*/
+import "C"
+
+type RtpReceiver struct {
+	p *refptr
+	r C.CGO_RtpReceiver
+}
+
+func newRtpReceiver(r C.CGO_RtpReceiver) *RtpReceiver {
+	return &RtpReceiver{
+		p: newRefPtr(C.CGO_RefPtr(r)),
+		r: r,
+	}
+}
+
+func (r *RtpReceiver) Track() MediaStreamTrack {
+	isAudio := false
+	t := C.CGO_RtpReceiver_Track(r.r, (*C.bool)(&isAudio))
+	if isAudio {
+		return newAudioTrack(C.CGO_AudioTrack(t))
+	}
+	panic("VideoTrack not yet implemented")
+}

--- a/rtpreceiver.h
+++ b/rtpreceiver.h
@@ -1,0 +1,26 @@
+#ifndef _C_RTPRECEIVER_H_
+#define _C_RTPRECEIVER_H_
+
+#define WEBRTC_POSIX 1
+
+#include <stdbool.h>
+
+#include "mediastreamtrack.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_RtpReceiver; // webrtc::RtpReceiverInterface*
+
+  CGO_MediaStreamTrack CGO_RtpReceiver_Track(CGO_RtpReceiver, bool*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_RTPRECEIVER_H_

--- a/rtpsender.cc
+++ b/rtpsender.cc
@@ -1,0 +1,9 @@
+#include "rtpsender.h"
+
+#include "webrtc/api/rtpsenderinterface.h"
+
+CGO_MediaStreamTrack CGO_RtpSender_Track(CGO_RtpSender s, bool* isAudio) {
+	auto t = ((webrtc::RtpSenderInterface*)s)->track().release();
+	*isAudio = t->kind() == "audio";
+	return t;
+}

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -1,0 +1,29 @@
+package webrtc
+
+/*
+#include "refptr.h"
+#include "rtpsender.h"
+#include "audiotrack.h"
+*/
+import "C"
+
+type RtpSender struct {
+	p *refptr
+	s C.CGO_RtpSender
+}
+
+func newRtpSender(s C.CGO_RtpSender) *RtpSender {
+	return &RtpSender{
+		p: newRefPtr(C.CGO_RefPtr(s)),
+		s: s,
+	}
+}
+
+func (s *RtpSender) Track() MediaStreamTrack {
+	isAudio := false
+	t := C.CGO_RtpSender_Track(s.s, (*C.bool)(&isAudio))
+	if isAudio {
+		return newAudioTrack(C.CGO_AudioTrack(t))
+	}
+	panic("VideoTrack not yet implemented")
+}

--- a/rtpsender.h
+++ b/rtpsender.h
@@ -1,0 +1,26 @@
+#ifndef _C_RTPSENDER_H_
+#define _C_RTPSENDER_H_
+
+#define WEBRTC_POSIX 1
+
+#include <stdbool.h>
+
+#include "mediastreamtrack.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // In order to present an interface cgo is happy with, nothing in this file
+  // can directly reference header files from libwebrtc / C++ world. All the
+  // casting must be hidden in the .cc file.
+
+  typedef void* CGO_RtpSender; // webrtc::RtpSenderInterface*
+
+  CGO_MediaStreamTrack CGO_RtpSender_Track(CGO_RtpSender, bool*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _C_RTPSENDER_H_


### PR DESCRIPTION
My motivation for implementing this only included receiving and sending audio (as a back-end service would do), not recording or playing audio from/to microphone and speakers (as a front-end app might).  Therefore, I stuck with a fake AudioDeviceModule [0].  Down the road, it might be desirable to allow real AudioDeviceModules.

addresses #7 

[0]  Another reason for using a fake AudioDeviceModule was so I could disable its capture and push of audio, which audio ended up being interleaved with the audio from sent tracks, corrupting it on the receiving end.  There must be a better way to fix this, but I couldn't find it.