### PR TITLE
Take object files only from obj/ in build.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -110,13 +110,13 @@ popd
 echo "Concatenating libraries ..."
 pushd $WEBRTC_SRC/out/$CONFIG
 if [ "$OS" = "darwin" ]; then
-	find . -name '*.o' > filelist
+	find obj -name '*.o' > filelist
 	libtool -static -o libwebrtc-magic.a -filelist filelist
 	strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
 elif [ "$ARCH" = "arm" ]; then
-	arm-linux-gnueabihf-ar crs libwebrtc-magic.a $(find . -name '*.o' -not -name '*.main.o')
+	arm-linux-gnueabihf-ar crs libwebrtc-magic.a $(find obj -name '*.o')
 else
-	ar crs libwebrtc-magic.a $(find . -name '*.o' -not -name '*.main.o')
+	ar crs libwebrtc-magic.a $(find obj -name '*.o')
 fi
 OUT_LIBRARY=$LIB_DIR/libwebrtc-$OS-$ARCH-magic.a
 mv libwebrtc-magic.a ${OUT_LIBRARY}


### PR DESCRIPTION
See https://bugs.torproject.org/22832#comment:6 : object files from
outside of that directory are not intended for the final library output.
They may not even be of the correct architecture. It's no longer
necessary to exclude '*.main.o', because those files were in different
subdirectories.

----

I tested this by rebuilding the linux-amd64 magic, and bootstrapping snowflake-client.