### PR TITLE
port to Android

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,164 @@
+
+# use the packages for Go
+.ubuntu-template: &ubuntu-template
+  variables:
+    DEBIAN_FRONTEND: noninteractive
+    GOPATH: /usr/share/gocode
+  before_script:
+    - apt-get -qy update
+    - apt-get -qy install --no-install-recommends
+        build-essential
+        git
+        golang-github-smartystreets-goconvey-dev
+        golang-race-detector-runtime
+        libx11-dev
+        locales
+        pkg-config
+    - mkdir -p $GOPATH
+
+# use Go installed as part of the official, Debian-based Docker images
+.golang-docker-debian-template: &golang-docker-debian-template
+  variables:
+    DEBIAN_FRONTEND: noninteractive
+  before_script:
+    - apt-get -qy update
+    - apt-get -qy install --no-install-recommends
+        ca-certificates
+        git
+        lbzip2
+        libx11-dev
+        locales
+        pkg-config
+        wget
+        xz-utils
+    - go get github.com/smartystreets/goconvey/convey
+
+.build_env_setup: &build_env_setup |
+  set -x
+  cat /etc/apt/sources.list | sed 's,^deb,deb-src,' >> /etc/apt/sources.list
+  apt-get -qy update
+  apt-get -qy install --no-install-recommends git locales
+  apt-get -qy build-dep chromium-browser
+  # libwebrtc build wants en_US.UTF-8
+  grep '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+  locale-gen
+  # Create symbolic links under $GOPATH, this is needed for local build
+  export src=$GOPATH/src
+  mkdir -p $src/github.com/keroserene
+  mkdir -p $src/gitlab.com/$CI_PROJECT_NAMESPACE
+  ln -s $CI_PROJECT_DIR $src/github.com/keroserene/go-webrtc
+  ln -s $CI_PROJECT_DIR $src/gitlab.com/$CI_PROJECT_PATH
+    # build libwebrtc binaries
+  git config --global user.name "John Doe"
+  git config --global user.email "jdoe@email.com"
+  git config --global core.autocrlf false
+  git config --global core.filemode false
+  rm -rf include/ lib/
+  set +x
+
+.artifacts-template: &artifacts-template
+  artifacts:
+    name: "${CI_PROJECT_PATH}_${CI_JOB_STAGE}_${CI_COMMIT_REF_NAME}_${CI_COMMIT_SHA}"
+    paths:
+      - include/
+      - lib/
+    when:
+      always
+    expire_in: 1 day
+  after_script:
+    - echo "Download debug artifacts from https://gitlab.com/${CI_PROJECT_PATH}/-/jobs"
+
+.script-template: &script-template
+  except:
+    - schedules
+  script:
+    # Create symbolic links under $GOPATH, this is needed for local build
+    - export src=$GOPATH/src
+    - mkdir -p $src/github.com/keroserene
+    - mkdir -p $src/gitlab.com/$CI_PROJECT_NAMESPACE
+    - ln -s $CI_PROJECT_DIR $src/github.com/keroserene/go-webrtc
+    - ln -s $CI_PROJECT_DIR $src/gitlab.com/$CI_PROJECT_PATH
+
+    # build it for go
+    - cd $src/github.com/keroserene/go-webrtc
+    - go get -v .
+    - go build -v -x .
+    - go vet -v .
+    - go test -v -race .
+
+
+# -- jobs ------------------------------------------------------------
+
+debian-stretch_go-1.10:
+  image: golang:1.10-stretch
+  <<: *golang-docker-debian-template
+  <<: *artifacts-template
+  <<: *script-template
+
+debian-stretch_go-1.11:
+  image: golang:1.11-stretch
+  <<: *golang-docker-debian-template
+  <<: *artifacts-template
+  <<: *script-template
+
+ubuntu-devel:
+  image: ubuntu:devel
+  <<: *ubuntu-template
+  <<: *artifacts-template
+  <<: *script-template
+
+ubuntu-rolling:
+  image: ubuntu:rolling
+  <<: *ubuntu-template
+  <<: *artifacts-template
+  <<: *script-template
+
+ubuntu-lts:
+  image: ubuntu:latest
+  <<: *ubuntu-template
+  <<: *artifacts-template
+  <<: *script-template
+
+libwebrtc-linux-amd64-magic:
+  only:
+    - schedules
+  image: debian:stretch
+  # this job needs 20+ gigs of disk
+  tags:
+    - largedisk
+  <<: *artifacts-template
+  script:
+    - *build_env_setup
+    - GOOS=linux GOARCH=amd64 ./build.sh
+
+libwebrtc-linux-arm-magic:
+  only:
+    - schedules
+  image: debian:stretch
+  # this job needs 20+ gigs of disk
+  tags:
+    - largedisk
+  <<: *artifacts-template
+  script:
+    - *build_env_setup
+    - apt-get -qy install --no-install-recommends binutils-arm-linux-gnueabihf
+    - GOOS=linux GOARCH=arm ./build.sh
+
+android:
+  image: golang:1.11-stretch
+  # this job needs 20+ gigs of disk
+  tags:
+    - largedisk
+  only:
+    - schedules
+  <<: *golang-docker-debian-template
+  <<: *artifacts-template
+  script:
+    - *build_env_setup
+    - apt-get -qy install --no-install-recommends lsb-release sudo
+    - export WEBRTC_SRC="$CI_PROJECT_DIR/third_party/webrtc/src"
+    - export ANDROID_HOME=$WEBRTC_SRC/third_party/android_tools/sdk
+    - GOOS=android GOARCH=arm ./build.sh || ( $WEBRTC_SRC/build/install-build-deps-android.sh && GOOS=android GOARCH=arm ./build.sh )
+  after_script:
+    - cat third_party/webrtc/.gclient || true
+    - cat third_party/webrtc/.gclient_entries || true

--- a/build.sh
+++ b/build.sh
@@ -98,7 +98,7 @@ popd
 
 echo "Building webrtc ..."
 pushd $WEBRTC_SRC
-gn gen out/$CONFIG --args="target_os=\"$TARGET_OS\" target_cpu=\"$TARGET_CPU\" is_debug=false use_custom_libcxx=false" || exit 1
+gn gen out/$CONFIG --args="target_os=\"$TARGET_OS\" target_cpu=\"$TARGET_CPU\" is_debug=false symbol_level=0 use_custom_libcxx=false" || exit 1
 ninja -C out/$CONFIG webrtc field_trial metrics_default pc_test_utils || exit 1
 popd
 

--- a/build.sh
+++ b/build.sh
@@ -123,10 +123,10 @@ if [ "$OS" = "darwin" ]; then
 	strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
 elif [ "$ARCH" = "arm" ]; then
 	find obj -name '*.o' -print0 | sort -z \
-		| xargs -0 -- arm-linux-gnueabihf-ar crs libwebrtc-magic.a
+		| xargs -0 -- arm-linux-gnueabihf-ar crsD libwebrtc-magic.a
 else
 	find obj -name '*.o' -print0 | sort -z \
-		| xargs -0 -- ar crs libwebrtc-magic.a
+		| xargs -0 -- ar crsD libwebrtc-magic.a
 fi
 OUT_LIBRARY=$LIB_DIR/libwebrtc-$OS-$ARCH-magic.a
 mv libwebrtc-magic.a ${OUT_LIBRARY}

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ COMMIT="88f5d9180eae78a6162cccd78850ff416eb82483"  # branch-heads/64
 
 # Values are from,
 #   https://github.com/golang/go/blob/master/src/go/build/syslist.go
-#   https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/reference.md
+#   https://gn.googlesource.com/gn/+/master/docs/reference.md
 
 oses=",linux:linux,darwin:mac,windows:win,android:android,"
 cpus=",386:x86,amd64:x64,arm:arm,"

--- a/datachannel.go
+++ b/datachannel.go
@@ -9,6 +9,7 @@ package webrtc
 /*
 #cgo CXXFLAGS: -std=c++0x
 #cgo LDFLAGS: -L${SRCDIR}/lib
+#cgo android pkg-config: webrtc-android-armeabi-v7a.pc
 #cgo linux,arm pkg-config: webrtc-linux-arm.pc
 #cgo linux,386 pkg-config: webrtc-linux-386.pc
 #cgo linux,amd64 pkg-config: webrtc-linux-amd64.pc

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -32,6 +32,7 @@ package webrtc
 /*
 #cgo CXXFLAGS: -std=c++0x
 #cgo LDFLAGS: -L${SRCDIR}/lib
+#cgo android pkg-config: webrtc-android-armeabi-v7a.pc
 #cgo linux,arm pkg-config: webrtc-linux-arm.pc
 #cgo linux,386 pkg-config: webrtc-linux-386.pc
 #cgo linux,amd64 pkg-config: webrtc-linux-amd64.pc

--- a/webrtc-android-armeabi-v7a.pc
+++ b/webrtc-android-armeabi-v7a.pc
@@ -1,0 +1,17 @@
+pc=${pcfiledir}
+
+Name: webrtc
+Description: webrtc
+Version: 1
+
+Cflags: \
+	-I${pc}/include \
+	-DPOSIX \
+	-DWEBRTC_ANDROID
+
+Libs: \
+	-L${pc}/lib \
+	-lwebrtc-android-arm-magic \
+	-lOpenSLES \
+	-llog \
+	-ldl


### PR DESCRIPTION
This ports go-webrtc to Android.  Most of that was getting a repeatable build process for the libwebrtc component and pointing the go code to that binary.  You can find the details of this epic saga here:
https://trac.torproject.org/projects/tor/ticket/28205  #82

In the end, I also got the whole process running in GitLab CI, including building the libwebrtc binaries for GNU/Linux amd64 and ARM. This should close out #32 For example, here is building the _libwebrtc.a_ binary part for Debian and Android (close but not quite working):
https://gitlab.com/eighthave/go-webrtc/pipelines/37556080

And here is building the whole thing using the committed _libwebrtc.a_ binaries, this runs on Debian/stretch using the Go 1.10 and 1.11 binaries, then on Ubuntu/LTS, Ubuntu/cosmic, and Ubuntu/devel using the Go from Ubuntu:
https://gitlab.com/eighthave/go-webrtc/pipelines/37555959

Once this is merged, gitlab will automatically build all commits in this repo here:
https://gitlab.com/torproject/go-webrtc/pipelines

The process for building _libwebrtc.a_ is pretty huge, so that runs just once a month via a schedule:
https://gitlab.com/torproject/go-webrtc/pipeline_schedules

@arlolra @n8fr8 @uniqx