### PR TITLE
Switch from dist:trusty to dist:xenial in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 matrix:
     include:
         - os: linux
-          dist: trusty
+          dist: xenial
           sudo: required
           go: 1.6
           env: CC="gcc-5" CXX="g++-5" OS="linux"


### PR DESCRIPTION
This is another provisional test pull request like #92. I'm running this one because #92 is running into asan errors--but I'm also getting asan errors currently on my desktop on master. So this branch only changes `dist:trusty` to `dist:xenial`, without the `_GLIBCXX_USE_CXX11_ABI` changes.