### PR TITLE
Put -fsanitize=address in CGO_CXXFLAGS, not only CGO_CFLAGS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
     - go vet .
     - go test -v -race .
     # Only linux until https://github.com/golang/go/issues/16150 is fixed.
-    - if [[ "$OS" == "linux" ]]; then CGO_CFLAGS="-fsanitize=address" CGO_LDFLAGS="-fsanitize=address -fuse-ld=gold" go test -v .; fi
+    - if [[ "$OS" == "linux" ]]; then CGO_CFLAGS="-fsanitize=address" CGO_CXXFLAGS="-fsanitize=address" CGO_LDFLAGS="-fsanitize=address -fuse-ld=gold" go test -v .; fi


### PR DESCRIPTION
While experimenting with #81 and #92, I was manually editing command lines and discovered this error after adding `-fsanitize=address` to `CGO_CXXFLAGS` (currently it's only set in `CGO_CFLAGS`).
```
$ CGO_CFLAGS="-fsanitize=address" CGO_CXXFLAGS="-fsanitize=address" CGO_LDFLAGS="-fsanitize=address -fuse-ld=gold" go test -run TestDataStateEnums
....
4 total assertions

............................=================================================================
==9442==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7fff531df088 at pc 0x00000058f2aa bp 0x7fff531df040 sp 0x7fff531df038
WRITE of size 8 at 0x7fff531df088 thread T0
    #0 0x58f2a9 in rtc::scoped_refptr<webrtc::DataChannelInterface>::scoped_refptr<FakeDataChannel>(rtc::scoped_refptr<FakeDataChannel> const&) (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x58f2a9)
    #1 0x58ecf0 in rtc::RefCountedObject<CGoDataChannelObserver>::RefCountedObject<rtc::scoped_refptr<FakeDataChannel>&>(rtc::scoped_refptr<FakeDataChannel>&) (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x58ecf0)
    #2 0x584a31 in CGO_getFakeDataChannel (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x584a31)
    #3 0x5806c0 in _cgo_aeba63b75ef5_Cfunc_CGO_getFakeDataChannel (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x5806c0)
    #4 0x49218f in runtime.asmcgocall (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x49218f)

Address 0x7fff531df088 is located in stack of thread T0==9442==AddressSanitizer CHECK failed: ../../../../src/libsanitizer/asan/asan_thread.cc:243 "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
    #0 0x7f0eb17dbebd  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xcaebd)
    #1 0x7f0eb17e1b13 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xd0b13)
    #2 0x7f0eb17df759  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xce759)
    #3 0x7f0eb17d7bd7  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc6bd7)
    #4 0x7f0eb17d818a  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc718a)
    #5 0x7f0eb17db376  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xca376)
    #6 0x7f0eb17dc66a in __asan_report_store8 (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xcb66a)
    #7 0x58f2a9 in rtc::scoped_refptr<webrtc::DataChannelInterface>::scoped_refptr<FakeDataChannel>(rtc::scoped_refptr<FakeDataChannel> const&) (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x58f2a9)
    #8 0x58ecf0 in rtc::RefCountedObject<CGoDataChannelObserver>::RefCountedObject<rtc::scoped_refptr<FakeDataChannel>&>(rtc::scoped_refptr<FakeDataChannel>&) (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x58ecf0)
    #9 0x584a31 in CGO_getFakeDataChannel (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x584a31)
    #10 0x5806c0 in _cgo_aeba63b75ef5_Cfunc_CGO_getFakeDataChannel (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x5806c0)
    #11 0x49218f in runtime.asmcgocall (/tmp/go-build733118686/_/home/user/go-webrtc/_test/go-webrtc.test+0x49218f)

exit status 1
FAIL    _/home/user/go-webrtc 0.030s
```