### PR TITLE
Use whitespace-safe loops in build.sh, sort inputs to ar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -105,9 +105,9 @@ popd
 echo "Copying headers ..."
 pushd $WEBRTC_SRC || exit 1
 rm -rf "$INCLUDE_DIR"
-for h in $(find . -type f -name '*.h')
+find . -type f -name '*.h' -print0 | while IFS= read -r -d '' h;
 do
-	mkdir -p "$INCLUDE_DIR/$(dirname $h)"
+	mkdir -p "$INCLUDE_DIR/$(dirname "$h")"
 	cp $h "$INCLUDE_DIR/$h"
 done
 popd
@@ -118,13 +118,15 @@ popd
 echo "Concatenating libraries ..."
 pushd $WEBRTC_SRC/out/$CONFIG
 if [ "$OS" = "darwin" ]; then
-	find obj -name '*.o' > filelist
-	libtool -static -o libwebrtc-magic.a -filelist filelist
+	find obj -name '*.o' -print0 \
+		| xargs -0 -- libtool -static -o libwebrtc-magic.a
 	strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
 elif [ "$ARCH" = "arm" ]; then
-	arm-linux-gnueabihf-ar crs libwebrtc-magic.a $(find obj -name '*.o')
+	find obj -name '*.o' -print0 \
+		| xargs -0 -- arm-linux-gnueabihf-ar crs libwebrtc-magic.a
 else
-	ar crs libwebrtc-magic.a $(find obj -name '*.o')
+	find obj -name '*.o' -print0 \
+		| xargs -0 -- ar crs libwebrtc-magic.a
 fi
 OUT_LIBRARY=$LIB_DIR/libwebrtc-$OS-$ARCH-magic.a
 mv libwebrtc-magic.a ${OUT_LIBRARY}

--- a/build.sh
+++ b/build.sh
@@ -122,10 +122,10 @@ if [ "$OS" = "darwin" ]; then
 		| xargs -0 -- libtool -static -o libwebrtc-magic.a
 	strip -S -x -o libwebrtc-magic.a libwebrtc-magic.a
 elif [ "$ARCH" = "arm" ]; then
-	find obj -name '*.o' -print0 \
+	find obj -name '*.o' -print0 | sort -z \
 		| xargs -0 -- arm-linux-gnueabihf-ar crs libwebrtc-magic.a
 else
-	find obj -name '*.o' -print0 \
+	find obj -name '*.o' -print0 | sort -z \
 		| xargs -0 -- ar crs libwebrtc-magic.a
 fi
 OUT_LIBRARY=$LIB_DIR/libwebrtc-$OS-$ARCH-magic.a


### PR DESCRIPTION
Our `find . -type f -name '*.h'` and `find obj -name '*.o'` loops don't work with filenames containing whitespace. I haven't had any problems with this personally, but Georg Koppen reported a problem at https://bugs.torproject.org/28725#comment:3. The first patch fixes that. It's tested on linux-amd64 and linux-arm but not darwin-amd64. It's essentially the same change as:
https://gitweb.torproject.org/builders/tor-browser-build.git/commit/?id=d8db312e4527c694e8f906a5e8926d0dc0c37179

The second patch sorts the inputs to `ar` so we have a better shot at being deterministic. Except on darwin, because I couldn't see that BSD `sort` supports the `-z` option for NUL-separated inputs.