### PR TITLE
Make stack non-executable

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -8,7 +8,7 @@ package webrtc
 
 /*
 #cgo CXXFLAGS: -std=c++0x
-#cgo LDFLAGS: -L${SRCDIR}/lib
+#cgo LDFLAGS: -L${SRCDIR}/lib -z noexecstack
 #cgo android pkg-config: webrtc-android-armeabi-v7a.pc
 #cgo linux,arm pkg-config: webrtc-linux-arm.pc
 #cgo linux,386 pkg-config: webrtc-linux-386.pc

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -31,7 +31,7 @@ package webrtc
 
 /*
 #cgo CXXFLAGS: -std=c++0x
-#cgo LDFLAGS: -L${SRCDIR}/lib
+#cgo LDFLAGS: -L${SRCDIR}/lib -z noexecstack
 #cgo android pkg-config: webrtc-android-armeabi-v7a.pc
 #cgo linux,arm pkg-config: webrtc-linux-arm.pc
 #cgo linux,386 pkg-config: webrtc-linux-386.pc


### PR DESCRIPTION
Fixes a bug where go programs that rely on this library have executable
stacks.

In order to build this library with these ld flags, the environment
variable CGO_LDFLAGS_ALLOW must be set to a regex that will accept the
-z flag. The value "-z|noexecstack" is sufficient. Otherwise the build
will fail with the message "invalid flag in #cgo LDFLAGS". This is due
to the whitelisting of allowed flags for security purposes.